### PR TITLE
fix: refresh before reading files

### DIFF
--- a/src/commands/force/org/display.ts
+++ b/src/commands/force/org/display.ts
@@ -27,6 +27,13 @@ export class OrgDisplayCommand extends SfdxCommand {
   };
 
   public async run(): Promise<OrgDisplayReturn> {
+    try {
+      // the auth file might have a stale access token.  We want to refresh it before getting the fields
+      await this.org.refreshAuth();
+    } catch (error) {
+      // even if this fails, we want to display the information we can read from the auth file
+      this.ux.warn('unable to refresh auth for org');
+    }
     // translate to alias if necessary
     const authInfo = await AuthInfo.create({ username: this.org.getUsername() });
     const fields = authInfo.getFields(true);


### PR DESCRIPTION
### What does this PR do?
refresh auth before reading the files to prevent display of stale accessTokens

### What issues does this PR fix or reference?
@W-8886636@