### PR TITLE
fix: clean up help and add examples back to force:org:list

### DIFF
--- a/messages/list.json
+++ b/messages/list.json
@@ -10,7 +10,7 @@
   "all": "include expired, deleted, and unknown-status scratch orgs",
   "clean": "remove all local org authorizations for non-active orgs",
   "noPrompt": "do not prompt for confirmation",
-  "skipConnectionStatus": "skips retrieving the connection status of non-scratch orgs",
+  "skipConnectionStatus": "skip retrieving the connection status of non-scratch orgs",
 
   "prompt": "Found (%s) org configurations to delete. Are you sure (yes/no)?",
   "noActiveScratchOrgs": "No active scratch orgs found. Specify --all to see all scratch orgs",

--- a/messages/open.json
+++ b/messages/open.json
@@ -1,5 +1,5 @@
 {
-  "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it to your browser, specify --urlonly.",
+  "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it in your browser, specify --urlonly.",
   "examples": [
     "sfdx force:org:open",
     "sfdx force:org:open -u me@my.org",

--- a/messages/open.json
+++ b/messages/open.json
@@ -1,5 +1,5 @@
 {
-  "description": "open your default scratch org, or another org that you specify,\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch your browser, specify --urlonly",
+  "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it to your browser, specify --urlonly.",
   "examples": [
     "sfdx force:org:open",
     "sfdx force:org:open -u me@my.org",

--- a/src/commands/force/org/list.ts
+++ b/src/commands/force/org/list.ts
@@ -17,7 +17,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-org', 'list');
 
 export class OrgListCommand extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
-
+  public static readonly examples = messages.getMessage('examples').split(EOL);
   public static readonly requiresProject = false;
   public static readonly flagsConfig: FlagsConfig = {
     verbose: flags.builtin({

--- a/src/commands/force/org/list.ts
+++ b/src/commands/force/org/list.ts
@@ -4,6 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { EOL } from 'os';
+
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { AuthInfo, ConfigAggregator, ConfigInfo, Connection, Org, SfdxError, Messages } from '@salesforce/core';
 import { sortBy } from '@salesforce/kit';


### PR DESCRIPTION
### What does this PR do?

Cleans up help and adds examples back to force:org:list

### What issues does this PR fix or reference?

@W-8995248@