### PR TITLE
feat: namespace on orgList

### DIFF
--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -271,6 +271,7 @@ export class OrgListUtil {
         scratchOrgInfo.status = updatedOrgInfo.Status;
         scratchOrgInfo.expirationDate = updatedOrgInfo.ExpirationDate;
         scratchOrgInfo.isExpired = updatedOrgInfo.Status === 'Deleted';
+        scratchOrgInfo.namespace = updatedOrgInfo.Namespace;
         // the old toolbelt code always said Unknown.  I'd love to get rid of it.
         scratchOrgInfo.connectedStatus = 'Unknown';
       } else {

--- a/test/nut/commands/force/org/org.nut.ts
+++ b/test/nut/commands/force/org/org.nut.ts
@@ -81,9 +81,11 @@ describe('Org Command NUT', () => {
       expect(scratchOrgs.map((org) => asDictionary(org)).find((org) => org.username === defaultUsername)).to.include({
         defaultMarker: '(U)',
         isDefaultUsername: true,
+        namespace: null,
       });
       expect(scratchOrgs.map((org) => asDictionary(org)).find((org) => org.username === aliasedUsername)).to.include({
         alias: 'anAlias',
+        namespace: null,
       });
       expect(nonScratchOrgs).to.include(
         {


### PR DESCRIPTION
### What does this PR do?
adds the scratch org namespace value to json output of org:list (for parity...org display already had that field) 

### What issues does this PR fix or reference?
@W-9788406@
https://github.com/forcedotcom/cli/issues/1146