### PR TITLE
feat: support targeting browser in "open" command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -12,6 +12,6 @@
   {
     "command": "force:org:open",
     "plugin": "@salesforce/plugin-org",
-    "flags": ["path", "urlonly", "json", "loglevel", "targetusername", "apiversion"]
+    "flags": ["path", "urlonly", "json", "loglevel", "targetusername", "apiversion", "browser"]
   }
 ]

--- a/messages/open.json
+++ b/messages/open.json
@@ -1,11 +1,13 @@
 {
-  "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it in your browser, specify --urlonly.",
+  "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"yourInstance.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it in your browser, specify --urlonly.\nTo open in a specific browser, use the --browser parameter. Supported browsers are \"chrome\", \"edge\", and \"firefox\". If you don't specify --browser, the org opens in your default browser.",
   "examples": [
     "sfdx force:org:open",
     "sfdx force:org:open -u me@my.org",
     "sfdx force:org:open -u MyTestOrg1",
-    "sfdx force:org:open -r -p lightning"
+    "sfdx force:org:open -r -p lightning",
+    "sfdx force:org:open -u me@my.org -b firefox"
   ],
+  "browser": "browser where the org opens",
   "cliPath": "navigation URL path",
   "urlonly": "display navigation URL, but don’t launch browser",
   "containerAction": "You are in a headless environment. To access the org %s, open this URL in a browser:\n\n%s",

--- a/src/commands/force/org/open.ts
+++ b/src/commands/force/org/open.ts
@@ -9,6 +9,7 @@ import { EOL } from 'os';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Messages, Org, SfdcUrl, SfdxError } from '@salesforce/core';
 import { Duration, Env } from '@salesforce/kit';
+import open = require('open');
 import { openUrl } from '../../../shared/utils';
 
 Messages.importMessagesDirectory(__dirname);
@@ -20,6 +21,12 @@ export class OrgOpenCommand extends SfdxCommand {
   public static readonly examples = messages.getMessage('examples').split(EOL);
   public static readonly requiresUsername = true;
   public static readonly flagsConfig: FlagsConfig = {
+    browser: flags.string({
+      char: 'b',
+      description: messages.getMessage('browser'),
+      options: ['chrome', 'edge', 'firefox'], // These are ones supported by "open" package
+      exclusive: ['urlonly'],
+    }),
     path: flags.string({
       char: 'p',
       description: messages.getMessage('cliPath'),
@@ -71,7 +78,12 @@ export class OrgOpenCommand extends SfdxCommand {
       }
       throw SfdxError.wrap(err);
     }
-    await openUrl(url);
+
+    const openOptions = this.flags.browser
+      ? { app: { name: open.apps[this.flags.browser as string] as open.AppName } }
+      : {};
+
+    await openUrl(url, openOptions);
     return output;
   }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -15,6 +15,6 @@ export const getAliasByUsername = async (username: string): Promise<string> => {
   return keys?.length ? keys[keys.length - 1] : undefined;
 };
 
-export const openUrl = async (url: string): Promise<ChildProcess> => {
-  return open(url);
+export const openUrl = async (url: string, options: open.Options): Promise<ChildProcess> => {
+  return open(url, options);
 };

--- a/test/commands/force/org/open.test.ts
+++ b/test/commands/force/org/open.test.ts
@@ -16,6 +16,7 @@ const orgId = '000000000000000';
 const username = 'test@test.org';
 const testPath = '/lightning/whatever';
 const testInstance = 'https://cs1.my.salesforce.com';
+const testBrowser = 'firefox';
 const accessToken = 'testAccessToken';
 const expectedDefaultUrl = `${testInstance}/secur/frontdoor.jsp?sid=${accessToken}`;
 const expectedUrl = `${expectedDefaultUrl}&retURL=${encodeURIComponent(testPath)}`;
@@ -186,6 +187,43 @@ describe('open commands', () => {
       .it('throws on dns fail', (ctx) => {
         expect(ctx.stderr).to.contain(messages.getMessage('domainTimeoutError'));
         expect(spies.get('resolver').callCount).to.equal(1);
+        expect(spies.get('open').callCount).to.equal(0);
+      });
+  });
+
+  describe('browser argument', () => {
+    test
+      .do(() => {
+        spies.set('resolver', stubMethod($$.SANDBOX, MyDomainResolver.prototype, 'resolve').resolves('1.1.1.1'));
+      })
+      .stdout()
+      .command(['force:org:open', '--targetusername', username, '--path', testPath])
+      .it('calls open with no browser argument', () => {
+        expect(spies.get('resolver').callCount).to.equal(1);
+        expect(spies.get('open').callCount).to.equal(1);
+        expect(spies.get('open').args[0][1]).to.eql({});
+      });
+
+    test
+      .do(() => {
+        spies.set('resolver', stubMethod($$.SANDBOX, MyDomainResolver.prototype, 'resolve').resolves('1.1.1.1'));
+      })
+      .stdout()
+      .command(['force:org:open', '--targetusername', username, '--path', testPath, '-b', testBrowser])
+      .it('calls open with a browser argument', () => {
+        expect(spies.get('resolver').callCount).to.equal(1);
+        expect(spies.get('open').callCount).to.equal(1);
+        expect(spies.get('open').args[0][1]).to.not.eql({});
+      });
+
+    test
+      .do(() => {
+        spies.set('resolver', stubMethod($$.SANDBOX, MyDomainResolver.prototype, 'resolve').resolves('1.1.1.1'));
+      })
+      .stdout()
+      .command(['force:org:open', '--targetusername', username, '--path', testPath, '-b', 'duff'])
+      .it('does not call open as passed unknown browser name', () => {
+        expect(spies.get('resolver').callCount).to.equal(0);
         expect(spies.get('open').callCount).to.equal(0);
       });
   });


### PR DESCRIPTION
### What does this PR do?
This PR adds an optional --browser flag to the open command to enable users to specify which browser application to use (e.g. Firefox, Chrome).
It does this by passing the argument through to the underlying "open" package.

An example (on mac) is;

`$ sfdx force:org:open -u MyAlias -b "chrome"`

This is a replica - more or less - of what was in #100 , but I was a plum and forgot to actually commit and push the last set of changes. With the amount of time and commits that have passed I thought it were best to rebase and create a new PR, instead of polluting it with lots of unrelated changes/merges etc. 

### What issues does this PR fix or reference?
This addresses the feature request #1015
