### PR TITLE
fix: org:delete scratch org + sandboxes

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,5 +1,10 @@
 [
   {
+    "command": "force:org:delete",
+    "plugin": "@salesforce/plugin-org",
+    "flags": ["apiversion", "json", "loglevel", "noprompt", "targetdevhubusername", "targetusername"]
+  },
+  {
     "command": "force:org:display",
     "plugin": "@salesforce/plugin-org",
     "flags": ["apiversion", "json", "loglevel", "targetusername", "verbose"]
@@ -12,6 +17,6 @@
   {
     "command": "force:org:open",
     "plugin": "@salesforce/plugin-org",
-    "flags": ["path", "urlonly", "json", "loglevel", "targetusername", "apiversion", "browser"]
+    "flags": ["apiversion", "browser", "json", "loglevel", "path", "targetusername", "urlonly"]
   }
 ]

--- a/messages/delete.json
+++ b/messages/delete.json
@@ -1,0 +1,13 @@
+{
+  "description": "mark a scratch or sandbox org for deletion \nTo mark the org for deletion without being prompted to confirm, specify --noprompt.",
+  "examples": ["$ sfdx force:org:delete -u me@my.org", "$ sfdx force:org:delete -u MyOrgAlias -p"],
+  "flags": {
+    "noprompt": "no prompt to confirm deletion"
+  },
+  "confirmDelete": "Enqueue %s org with name: %s for deletion?  Are you sure (y/n)?",
+  "sandboxConfigOnlySuccess": "Successfully deleted sandbox org %s.",
+  "attemptingToDeleteExpiredOrDeleted": "Attempting to delete an expired or deleted org",
+  "deleteOrgConfigOnlyCommandSuccess": "Successfully deleted scratch org %s.'",
+  "deleteOrgCommandSuccess": "Successfully marked scratch org %s for deletion",
+  "commandSandboxSuccess": "The sandbox org %s has been successfully removed from your list of CLI authorized orgs.  If you created the sandbox with one of the force:org commands, it has also been marked for deletion."
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@oclif/config": "^1",
     "@salesforce/command": "^4.1.3",
-    "@salesforce/core": "^2.28.2",
+    "@salesforce/core": "^2.30.0",
     "@salesforce/kit": "^1.5.17",
     "open": "8.4.0",
     "tslib": "^2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@oclif/config": "^1",
     "@salesforce/command": "^4.1.3",
-    "@salesforce/core": "^2.28.0",
+    "@salesforce/core": "^2.28.2",
     "@salesforce/kit": "^1.5.17",
     "open": "8.4.0",
     "tslib": "^2"

--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as os from 'os';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Messages, Org } from '@salesforce/core';
+import { SandboxOrgConfig } from '@salesforce/core/lib/config/sandboxOrgConfig';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete');
+
+type DeleteResult = {
+  orgId: string;
+  username: string;
+};
+
+export class Delete extends SfdxCommand {
+  public static readonly requiresUsername = true;
+  public static readonly supportsDevhubUsername = true;
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    noprompt: flags.boolean({
+      char: 'p',
+      description: messages.getMessage('flags.noprompt'),
+    }),
+  };
+  // because of requiresUsername
+  public org!: Org;
+
+  public async run(): Promise<DeleteResult> {
+    const isSandbox = !!(await this.org.getSandboxOrgConfigField(SandboxOrgConfig.Fields.PROD_ORG_USERNAME));
+    const orgType = isSandbox ? 'sandbox' : 'scratch';
+    // we either need permission to proceed without a prompt OR get the user to confirm
+    if (
+      this.flags.noprompt ||
+      (await this.ux.confirm(messages.getMessage('confirmDelete', [orgType, this.org.getUsername()])))
+    ) {
+      return isSandbox ? this.deleteSandbox() : this.deleteScratchOrg();
+    }
+  }
+
+  private async deleteSandbox(): Promise<DeleteResult> {
+    let successMessageKey = 'commandSandboxSuccess';
+    const result = { orgId: this.org.getOrgId(), username: this.org.getUsername() };
+    this.logger.debug('Delete started for sandbox org %s ', this.org.getUsername());
+    try {
+      await this.org.deleteSandbox(this.org.getOrgId());
+      this.logger.debug('Sandbox org %s successfully marked for deletion', this.org.getUsername());
+    } catch (e) {
+      const err = e as Error;
+      if (err.name === 'sandboxProcessNotFoundByOrgId') {
+        successMessageKey = 'sandboxConfigOnlySuccess';
+      } else {
+        throw err;
+      }
+    }
+    this.logger.debug('Sandbox org config %s has been successfully deleted', this.org.getUsername());
+    this.ux.log(messages.getMessage(successMessageKey, [this.org.getUsername()]));
+    return result;
+  }
+
+  private async deleteScratchOrg(): Promise<DeleteResult> {
+    let alreadyDeleted = false;
+    try {
+      await this.org.deleteScratchOrg(this.hubOrg);
+    } catch (e) {
+      const err = e as Error;
+      if (err.name === 'attemptingToDeleteExpiredOrDeleted') {
+        alreadyDeleted = true;
+      } else {
+        // Includes the "insufficientAccessToDelete" error.
+        throw err;
+      }
+    }
+
+    this.ux.log(
+      messages.getMessage(alreadyDeleted ? 'deleteOrgConfigOnlyCommandSuccess' : 'deleteOrgCommandSuccess', [
+        this.org.getUsername(),
+      ])
+    );
+
+    return {
+      orgId: this.org.getOrgId(),
+      username: this.org.getUsername(),
+    };
+  }
+}

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -320,14 +320,14 @@ export class OrgListUtil {
         const logger = await OrgListUtil.retrieveLogger();
         logger.trace(`error refreshing auth for org: ${org.getUsername()}`);
         logger.trace(error);
-        return error.code ?? error.message;
+        return (error.code ?? error.message) as string;
       }
     } catch (err) {
       const error = err as SfdxError;
       const logger = await OrgListUtil.retrieveLogger();
       logger.trace(`error refreshing auth for org: ${username}`);
       logger.trace(error);
-      return error.code ?? error.message ?? 'Unknown';
+      return (error.code ?? error.message ?? 'Unknown') as string;
     }
   }
 }

--- a/test/commands/force/org/delete.test.ts
+++ b/test/commands/force/org/delete.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Messages, Org, SfdxProject } from '@salesforce/core';
+import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
+import { IConfig } from '@oclif/config';
+import * as sinon from 'sinon';
+import { expect } from '@salesforce/command/lib/test';
+import { UX } from '@salesforce/command';
+import { Delete } from '../../../../src/commands/force/org/delete';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete');
+
+describe('org:delete', () => {
+  const sandbox = sinon.createSandbox();
+  const username = 'scratch-test@salesforce.com';
+  const sandboxUsername = 'sandbox-test@salesforce.com';
+  const orgId = '00D54000000KDltEAG';
+  const oclifConfigStub = fromStub(stubInterface<IConfig>(sandbox));
+
+  // stubs
+  let resolveProjectConfigStub: sinon.SinonStub;
+  let uxConfirmStub: sinon.SinonStub;
+  let uxLogStub: sinon.SinonStub;
+  let cmd: TestDelete;
+
+  class TestDelete extends Delete {
+    public async runIt() {
+      await this.init();
+      return this.run();
+    }
+    public setOrg(org: Org) {
+      this.org = org;
+    }
+    public setProject(project: SfdxProject) {
+      this.project = project;
+    }
+  }
+
+  const runDeleteCommand = async (
+    params: string[],
+    options: { isSandbox?: boolean; deleteScratchOrg?: string } = { isSandbox: false }
+  ) => {
+    cmd = new TestDelete(params, oclifConfigStub);
+    stubMethod(sandbox, cmd, 'assignProject').callsFake(() => {
+      const sfdxProjectStub = fromStub(
+        stubInterface<SfdxProject>(sandbox, {
+          resolveProjectConfig: resolveProjectConfigStub,
+        })
+      );
+      cmd.setProject(sfdxProjectStub);
+    });
+    stubMethod(sandbox, cmd, 'assignOrg').callsFake(() => {
+      const orgStubOptions = {
+        getSandboxOrgConfigField: () => {},
+        deleteScratchOrg: () => {},
+        getUsername: () => username,
+        getOrgId: () => orgId,
+      };
+
+      if (options.isSandbox) {
+        orgStubOptions.getSandboxOrgConfigField = () => sandboxUsername;
+      }
+
+      if (options.deleteScratchOrg) {
+        orgStubOptions.deleteScratchOrg = () => {
+          const e = new Error();
+          e.name = options.deleteScratchOrg;
+          throw e;
+        };
+      }
+
+      const orgStub = fromStub(stubInterface<Org>(sandbox, orgStubOptions));
+      cmd.setOrg(orgStub);
+    });
+    uxConfirmStub = stubMethod(sandbox, UX.prototype, 'confirm');
+    uxLogStub = stubMethod(sandbox, UX.prototype, 'log');
+
+    return cmd.runIt();
+  };
+
+  beforeEach(() => {});
+
+  describe('org:delete scratch orgs', () => {
+    it('will prompt before attempting to delete', async () => {
+      await runDeleteCommand([]);
+      expect(uxConfirmStub.calledOnce).to.equal(true);
+      expect(uxConfirmStub.firstCall.args[0]).to.equal(messages.getMessage('confirmDelete', ['scratch', username]));
+    });
+
+    it('will determine sandbox vs scratch org', async () => {
+      await runDeleteCommand([], { isSandbox: true });
+      expect(uxConfirmStub.calledOnce).to.equal(true);
+      expect(uxConfirmStub.firstCall.args[0]).to.equal(messages.getMessage('confirmDelete', ['sandbox', username]));
+    });
+
+    it('will NOT prompt before attempting to delete when flag is provided', async () => {
+      const res = await runDeleteCommand(['--noprompt']);
+      expect(uxConfirmStub.called).to.equal(false);
+      expect(res).to.deep.equal({ orgId, username });
+    });
+
+    it('will catch the attemptingToDeleteExpiredOrDeleted and wrap correctly', async () => {
+      const res = await runDeleteCommand(['--noprompt'], { deleteScratchOrg: 'attemptingToDeleteExpiredOrDeleted' });
+      expect(uxConfirmStub.called).to.equal(false);
+      expect(res).to.deep.equal({ orgId, username });
+
+      expect(uxLogStub.firstCall.args[0]).to.equal(
+        messages.getMessage('deleteOrgConfigOnlyCommandSuccess', [username])
+      );
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // describe('delete sandbox', () => {
+  //   it('sandbox delete success', async () => {
+  //     sandbox.stub(Org, 'create').callsFake(() => prodOrg);
+  //     orgDeleteCommand.flags = { targetusername: sbUser, noprompt: true };
+  //     orgDeleteCommand.org = {
+  //       getOrgId: () => sandboxOrgId,
+  //       getUsername: () => sbUser,
+  //       getSandboxOrgConfigField: () => prodUser,
+  //       remove: () => Promise.resolve(),
+  //     };
+  //     const spy = sinon.spy(orgDeleteCommand.org, 'remove');
+  //     await orgDeleteCommand.run();
+  //     expect(prodSandboxOrgMock.deleteSandbox.callCount).to.equal(1);
+  //     expect(prodOrg.getOrgId.callCount).to.equal(0);
+  //     expect(spy.called).to.be.true;
+  //   });
+  //
+  //   // eslint-disable-next-line @typescript-eslint/require-await
+  //   it('prod org user auth not found', async () => {
+  //     sandbox.stub(Org, 'create').callsFake(() => {
+  //       throw new Error('No org configuration found for name');
+  //     });
+  //     orgDeleteCommand.flags = { targetusername: sbUser, noprompt: true };
+  //     orgDeleteCommand.org = {
+  //       getOrgId: () => sandboxOrgId,
+  //       getUsername: () => sbUser,
+  //       getSandboxOrgConfigField: () => prodUser,
+  //       remove: () => Promise.resolve(),
+  //     };
+  //     expect(orgDeleteCommand.run()).to.be.rejectedWith(
+  //       Error,
+  //       new RegExp('No org configuration found for name'),
+  //       'should have thrown a Prod Org User not found error'
+  //     );
+  //   });
+  //
+  //   it('sandbox delete no SandboxProcess', async () => {
+  //     sandbox.stub(Org, 'create').callsFake(() => prodOrg);
+  //     orgDeleteCommand.flags = { targetusername: sbUser, noprompt: true };
+  //     orgDeleteCommand.org = {
+  //       getOrgId: () => sandboxOrgId,
+  //       getUsername: () => sbUser,
+  //       getSandboxOrgConfigField: () => prodUser,
+  //       remove: () => Promise.resolve(),
+  //     };
+  //     const spy = sinon.spy(orgDeleteCommand.org, 'remove');
+  //     prodSandboxOrgMock.deleteSandbox.throws(
+  //       new SfdxError('Attempting to delete an already deleted org', 'sandboxProcessNotFoundByOrgId')
+  //     );
+  //     await orgDeleteCommand.run();
+  //     expect(prodSandboxOrgMock.deleteSandbox.callCount).to.equal(1);
+  //     expect(prodOrg.getOrgId.callCount).to.equal(0);
+  //     expect(spy.called).to.be.true;
+  //   });
+  //
+  //   // eslint-disable-next-line @typescript-eslint/require-await
+  //   it('sandbox delete some failure', async () => {
+  //     sandbox.stub(Org, 'create').callsFake(() => prodOrg);
+  //     orgDeleteCommand.flags = { targetusername: sbUser, noprompt: true };
+  //     orgDeleteCommand.org = {
+  //       getOrgId: () => sandboxOrgId,
+  //       getUsername: () => sbUser,
+  //       getSandboxOrgConfigField: () => prodUser,
+  //       remove: () => Promise.resolve(),
+  //     };
+  //     prodSandboxOrgMock.deleteSandbox.throws(new SfdxError('Something went wrong', 'someFailure'));
+  //     expect(orgDeleteCommand.run()).to.be.rejectedWith(
+  //       Error,
+  //       new RegExp('Something went wrong'),
+  //       'should have thrown an exception'
+  //     );
+  //   });
+  //
+  //   // it('sandbox delete success with prompt', async () => {
+  //   //   sandbox.stub(Org, 'create').callsFake(() => prodOrg);
+  //   //   sandbox.stub(heroku, 'prompt').callsFake(() => BBPromise.resolve('y'));
+  //   //   orgDeleteCommand.flags = { targetusername: sbUser };
+  //   //   orgDeleteCommand.org = {
+  //   //     getOrgId: () => sandboxOrgId,
+  //   //     getUsername: () => sbUser,
+  //   //     getSandboxOrgConfigField: () => prodUser,
+  //   //     remove: () => Promise.resolve(),
+  //   //   };
+  //   //   const spy = sinon.spy(orgDeleteCommand.org, 'remove');
+  //   //   await orgDeleteCommand.run();
+  //   //   expect(prodSandboxOrgMock.deleteSandbox.callCount).to.equal(1);
+  //   //   expect(prodOrg.getOrgId.callCount).to.equal(0);
+  //   //   expect(spy.called).to.be.true;
+  //   // });
+  //
+  //   it('sandbox prompt no', async () => {
+  //     sandbox.stub(Org, 'create').callsFake(() => prodOrg);
+  //     sandbox.stub(heroku, 'prompt').callsFake(() => BBPromise.resolve('n'));
+  //     orgDeleteCommand.flags = { targetusername: sbUser };
+  //     orgDeleteCommand.org = {
+  //       getOrgId: () => sandboxOrgId,
+  //       getUsername: () => sbUser,
+  //       getSandboxOrgConfigField: () => prodUser,
+  //       remove: () => Promise.resolve(),
+  //     };
+  //     const spy = sinon.spy(orgDeleteCommand.org, 'remove');
+  //     await orgDeleteCommand.run();
+  //     expect(prodSandboxOrgMock.deleteSandbox.callCount).to.equal(0);
+  //     expect(prodOrg.getOrgId.callCount).to.equal(0);
+  //     expect(spy.called).to.be.false;
+  //   });
+  // });
+});

--- a/test/nut/commands/force/org/delete.org.nut.ts
+++ b/test/nut/commands/force/org/delete.org.nut.ts
@@ -33,6 +33,15 @@ describe('Delete Orgs', () => {
     }
   });
 
+  after(async () => {
+    try {
+      await session?.clean();
+    } catch (e) {
+      // do nothing, session?.clean() will try to remove files already removed by the org:delete and throw an error
+      // it will also unwrap other stubbed methods
+    }
+  });
+
   it('delete scratch orgs via config', () => {
     const result = execCmd('force:org:delete --noprompt --json', {
       ensureExitCode: 0,

--- a/test/nut/commands/force/org/delete.org.nut.ts
+++ b/test/nut/commands/force/org/delete.org.nut.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { AnyJson, getString, isArray } from '@salesforce/ts-types';
+import { expect } from '@salesforce/command/lib/test';
+// these NUTs are separated from org.nuts.ts because deleting orgs may interfere with the other NUTs
+describe('Delete Orgs', () => {
+  let session: TestSession;
+  let defaultUsername: string;
+  let aliasedUsername: string;
+  let defaultUserOrgId: string;
+  let aliasUserOrgId: string;
+
+  // create our own orgs to delete to avoid interfering with other NUTs/cleanup
+  before(async () => {
+    session = await TestSession.create({
+      project: { name: 'forceOrgList' },
+      setupCommands: [
+        'sfdx force:org:create -f config/project-scratch-def.json --setdefaultusername --wait 10',
+        'sfdx force:org:create -f config/project-scratch-def.json --setalias anAlias --wait 10',
+      ],
+    });
+
+    if (isArray<AnyJson>(session.setup)) {
+      defaultUsername = getString(session.setup[0], 'result.username');
+      defaultUserOrgId = getString(session.setup[0], 'result.orgId');
+      aliasedUsername = getString(session.setup[1], 'result.username');
+      aliasUserOrgId = getString(session.setup[1], 'result.orgId');
+    }
+  });
+
+  it('delete scratch orgs via config', () => {
+    const result = execCmd('force:org:delete --noprompt --json', {
+      ensureExitCode: 0,
+    }).jsonOutput.result;
+    expect(result).to.be.ok;
+    expect(result).to.deep.equal({ orgId: defaultUserOrgId, username: defaultUsername });
+  });
+
+  it('delete scratch orgs via alias', () => {
+    const result = execCmd('force:org:delete --targetusername anAlias --noprompt --json', {
+      ensureExitCode: 0,
+    }).jsonOutput.result;
+    expect(result).to.be.ok;
+    expect(result).to.deep.equal({ orgId: aliasUserOrgId, username: aliasedUsername });
+  });
+});

--- a/test/nut/commands/force/org/delete.org.nut.ts
+++ b/test/nut/commands/force/org/delete.org.nut.ts
@@ -48,4 +48,8 @@ describe('Delete Orgs', () => {
     expect(result).to.be.ok;
     expect(result).to.deep.equal({ orgId: aliasUserOrgId, username: aliasedUsername });
   });
+
+  describe.skip('sandbox', () => {
+    // TODO: figure out how to test sandboxes in NUTs
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,7 +660,7 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.2.0", "@salesforce/core@^2.23.4", "@salesforce/core@^2.24.0", "@salesforce/core@^2.28.0":
+"@salesforce/core@^2.2.0", "@salesforce/core@^2.23.4", "@salesforce/core@^2.24.0", "@salesforce/core@^2.28.0", "@salesforce/core@^2.28.2":
   version "2.28.2"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.28.2.tgz#02fed89297c8d373d7c0784390abbc0791599268"
   integrity sha512-ohKNx4v1QL5LMESavn9Bs0ZNA4cw3IGL+dOvP601SphKPCOMiDfZYzfqhtET4R4uTAnJKvtUsuyvQUwL2479jg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,17 +660,17 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.2.0", "@salesforce/core@^2.23.4", "@salesforce/core@^2.24.0", "@salesforce/core@^2.28.0", "@salesforce/core@^2.28.2":
-  version "2.28.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.28.2.tgz#02fed89297c8d373d7c0784390abbc0791599268"
-  integrity sha512-ohKNx4v1QL5LMESavn9Bs0ZNA4cw3IGL+dOvP601SphKPCOMiDfZYzfqhtET4R4uTAnJKvtUsuyvQUwL2479jg==
+"@salesforce/core@^2.2.0", "@salesforce/core@^2.23.4", "@salesforce/core@^2.24.0", "@salesforce/core@^2.28.0", "@salesforce/core@^2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.30.0.tgz#0cf52378d87f18a55d438a492fd13b4579f01105"
+  integrity sha512-Uh1XCEL9qnf7mBuKrKTzK3TIXlkZn+ZQyYOGW0taa2uanVu6BrVHC+2E689RFr/9vK6zv1NsJklg6B3zguekVw==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.0"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.5.13"
     "@types/graceful-fs" "^4.1.5"
-    "@types/jsforce" "^1.9.29"
+    "@types/jsforce" "^1.9.35"
     "@types/mkdirp" "^1.0.1"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
@@ -678,6 +678,7 @@
     jsforce "^1.10.1"
     jsonwebtoken "8.5.0"
     mkdirp "1.0.4"
+    semver "^7.3.5"
     sfdx-faye "^1.0.9"
     ts-retry-promise "^0.6.0"
 
@@ -883,7 +884,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jsforce@^1.9.29":
+"@types/jsforce@^1.9.35":
   version "1.9.35"
   resolved "https://registry.npmjs.org/@types/jsforce/-/jsforce-1.9.35.tgz#abda87c796910d286420b07a97382c782b576ca8"
   integrity sha512-GEb1iMAK8raElbBbozR7aVEuMl47jrPYLNkeh+3h2vLJIG21uQ/kOk4kPgMiMFwCmgfX4/tPDugnjb7qrMav4A==


### PR DESCRIPTION
### What does this PR do?
migrates `org:delete` from toolbelt
carries over messages and error messages
uses sfdx-core for new `delete` method on `Org`

requires https://github.com/forcedotcom/sfdx-core/pull/491

### @W-10144470@
