### PR TITLE
fix: add warning about using force:org:display --verbose

### DIFF
--- a/messages/display.json
+++ b/messages/display.json
@@ -1,5 +1,5 @@
 {
-  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
+  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Be careful when using this parameter.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
   "examples": [
     "sfdx force:org:display",
     "sfdx force:org:display -u me@my.org",

--- a/messages/display.json
+++ b/messages/display.json
@@ -1,5 +1,5 @@
 {
-  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Do not share or distribute this URL or token.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
+  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Don't share or distribute this URL or token.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
   "examples": [
     "sfdx force:org:display",
     "sfdx force:org:display -u me@my.org",

--- a/messages/display.json
+++ b/messages/display.json
@@ -1,5 +1,5 @@
 {
-  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Be careful when using this parameter.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
+  "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Do not share or distribute this URL or token.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
   "examples": [
     "sfdx force:org:display",
     "sfdx force:org:display -u me@my.org",


### PR DESCRIPTION
because output contains sfdx auth url which contains refresh token which contains sensitive information

### What does this PR do?

See above. Here's a screenshot of resulting --help output:

![image](https://user-images.githubusercontent.com/63259011/141387665-f30487f3-248a-4fe3-bd93-78b301d28c6e.png)


### What issues does this PR fix or reference?
@W-10165230@