### PR TITLE
fix: try to create local config first

### DIFF
--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -269,9 +269,14 @@ export class Create extends SfdxCommand {
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias, result);
     }
     if (this.flags.setdefaultusername) {
-      const globalConfig: Config = this.configAggregator.getGlobalConfig();
-      globalConfig.set(Config.DEFAULT_USERNAME, username);
-      const result = await globalConfig.write();
+      let config: Config;
+      try {
+        config = await Config.create({ isGlobal: false });
+      } catch {
+        config = await Config.create({ isGlobal: true });
+      }
+      const result = config.set(Config.DEFAULT_USERNAME, username);
+      await config.write();
       this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
     }
   }


### PR DESCRIPTION
### What does this PR do?
Tries to create local config first then falls back to global config in order to set the default username

### How to QA this:
1) if you want you can use `./bin/run` or link this plugin in sfdx by doing `sfdx plugins:link .` in the root of this folder
2) Using an org like `dreamhouse-lwc` create a new scratch org with the legacy command: `sfdx force:org:create -f config/project-scratch-def.json --setalias dreamhouse-lwc-legacy --durationdays 1 --setdefaultusername` 
3) Check out the default username with `sfdx config:list`
4) Create a new scratch org with beta command: `sfdx force:org:beta:create -f config/project-scratch-def.json --setalias dreamhouse-lwc --durationdays 1 --setdefaultusername`
5) Finally check the default username has changed with: `sfdx config:list`
### What issues does this PR fix or reference?
@W-10675890@
