### PR TITLE
fix: try to create local config first

### DIFF
--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -269,14 +269,15 @@ export class Create extends SfdxCommand {
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias, result);
     }
     if (this.flags.setdefaultusername) {
+      let config: Config;
       try {
-        const config = await Config.create({ isGlobal: false });
-        const result = config.set(Config.DEFAULT_USERNAME, username);
-        await config.write();
-        this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
-      } catch (error) {
-        this.logger.debug('Set defaultUsername failed with error: %s', error);
+        config = await Config.create({ isGlobal: false });
+      } catch {
+        config = await Config.create({ isGlobal: true });
       }
+      const result = config.set(Config.DEFAULT_USERNAME, username);
+      await config.write();
+      this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
     }
   }
   private async createScratchOrg(): Promise<ScratchOrgProcessObject> {

--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -269,9 +269,14 @@ export class Create extends SfdxCommand {
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias, result);
     }
     if (this.flags.setdefaultusername) {
-      const globalConfig: Config = this.configAggregator.getGlobalConfig();
-      globalConfig.set(Config.DEFAULT_USERNAME, username);
-      const result = await globalConfig.write();
+      let config: Config;
+      try {
+        config = await Config.create({ isGlobal: false });
+      } catch {
+        config = await Config.create({ isGlobal: true });
+      }
+      const result = config.set(Config.DEFAULT_USERNAME, username);
+      await config.write();
       this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
     }
   }

--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -269,15 +269,14 @@ export class Create extends SfdxCommand {
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias, result);
     }
     if (this.flags.setdefaultusername) {
-      let config: Config;
       try {
-        config = await Config.create({ isGlobal: false });
-      } catch {
-        config = await Config.create({ isGlobal: true });
+        const config = await Config.create({ isGlobal: false });
+        const result = config.set(Config.DEFAULT_USERNAME, username);
+        await config.write();
+        this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
+      } catch (error) {
+        this.logger.debug('Set defaultUsername failed with error: %s', error);
       }
-      const result = config.set(Config.DEFAULT_USERNAME, username);
-      await config.write();
-      this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
     }
   }
   private async createScratchOrg(): Promise<ScratchOrgProcessObject> {

--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -262,9 +262,9 @@ export class Create extends SfdxCommand {
   }
 
   private async setAliasAndDefaultUsername(username: string): Promise<void> {
+    const aliases = await Aliases.create(Aliases.getDefaultOptions());
     if (this.flags.setalias) {
-      const alias = await Aliases.create(Aliases.getDefaultOptions());
-      await alias.updateValue(this.flags.setalias, username);
+      await aliases.updateValue(this.flags.setalias, username);
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias);
     }
     if (this.flags.setdefaultusername) {
@@ -274,7 +274,8 @@ export class Create extends SfdxCommand {
       } catch {
         config = await Config.create({ isGlobal: true });
       }
-      const result = config.set(Config.DEFAULT_USERNAME, username);
+      const value = aliases.getKeysByValue(username)[0] || username;
+      const result = config.set(Config.DEFAULT_USERNAME, value);
       await config.write();
       this.logger.debug('Set defaultUsername: %s result: %s', this.flags.setdefaultusername, result);
     }

--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -263,7 +263,8 @@ export class Create extends SfdxCommand {
 
   private async setAliasAndDefaultUsername(username: string): Promise<void> {
     if (this.flags.setalias) {
-      await Aliases.parseAndUpdate([`${this.flags.setalias as string}=${username}`]);
+      const alias = await Aliases.create(Aliases.getDefaultOptions());
+      await alias.updateValue(this.flags.setalias, username);
       this.logger.debug('Set Alias: %s result: %s', this.flags.setalias);
     }
     if (this.flags.setdefaultusername) {

--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -263,10 +263,8 @@ export class Create extends SfdxCommand {
 
   private async setAliasAndDefaultUsername(username: string): Promise<void> {
     if (this.flags.setalias) {
-      const alias = await Aliases.create(Aliases.getDefaultOptions());
-      alias.set(this.flags.setalias, username);
-      const result = await alias.write();
-      this.logger.debug('Set Alias: %s result: %s', this.flags.setalias, result);
+      await Aliases.parseAndUpdate([`${this.flags.setalias as string}=${username}`]);
+      this.logger.debug('Set Alias: %s result: %s', this.flags.setalias);
     }
     if (this.flags.setdefaultusername) {
       let config: Config;

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -199,7 +199,13 @@ describe('org:create', () => {
         username: 'newScratchUsername',
       });
       const aliasStub = stubMethod(sandbox, Aliases.prototype, 'set');
-      const configStub = stubMethod(sandbox, Config.prototype, 'set');
+      const setStub = sandbox.spy();
+      const writeStub = sandbox.spy();
+      const configCreateStub = stubMethod(sandbox, Config, 'create').withArgs({ isGlobal: false }).resolves({
+        set: setStub,
+        write: writeStub,
+      });
+      // const configStub = stubMethod(sandbox, Config.prototype, 'set');
       await command.runIt();
       expect(prodOrg.firstCall.args[0]).to.deep.equal({
         apiversion: undefined,
@@ -217,7 +223,10 @@ describe('org:create', () => {
         orgConfig: {},
       });
       expect(aliasStub.firstCall.args).to.deep.equal(['sandboxAlias', 'newScratchUsername']);
-      expect(configStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
+      expect(configCreateStub.calledOnce).to.be.true;
+      expect(writeStub.calledOnce).to.be.true;
+      expect(configCreateStub.firstCall.firstArg).to.deep.equal({ isGlobal: false });
+      expect(setStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
     });
 
     it('will test json output', async () => {

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -184,7 +184,7 @@ describe('org:create', () => {
         '--type',
         'scratch',
         '--setalias',
-        'sandboxAlias',
+        'scratchOrgAlias',
         '--setdefaultusername',
         '--definitionfile',
         definitionfile,
@@ -198,7 +198,7 @@ describe('org:create', () => {
         ...CREATE_RESULT,
         username: 'newScratchUsername',
       });
-      const aliasStub = stubMethod(sandbox, Aliases.prototype, 'set');
+      const aliasStub = stubMethod(sandbox, Aliases, 'parseAndUpdate');
       const configStub = stubMethod(sandbox, Config.prototype, 'set');
       await command.runIt();
       expect(prodOrg.firstCall.args[0]).to.deep.equal({
@@ -216,7 +216,7 @@ describe('org:create', () => {
         retry: 0,
         orgConfig: {},
       });
-      expect(aliasStub.firstCall.args).to.deep.equal(['sandboxAlias', 'newScratchUsername']);
+      expect(aliasStub.firstCall.args).to.deep.equal([['scratchOrgAlias=newScratchUsername']]);
       expect(configStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
     });
 

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -198,7 +198,7 @@ describe('org:create', () => {
         ...CREATE_RESULT,
         username: 'newScratchUsername',
       });
-      const aliasStub = stubMethod(sandbox, Aliases, 'parseAndUpdate');
+      const aliasStub = stubMethod(sandbox, Aliases.prototype, 'updateValue');
       const configStub = stubMethod(sandbox, Config.prototype, 'set');
       await command.runIt();
       expect(prodOrg.firstCall.args[0]).to.deep.equal({
@@ -216,7 +216,7 @@ describe('org:create', () => {
         retry: 0,
         orgConfig: {},
       });
-      expect(aliasStub.firstCall.args).to.deep.equal([['scratchOrgAlias=newScratchUsername']]);
+      expect(aliasStub.firstCall.args).to.deep.equal(['scratchOrgAlias', 'newScratchUsername']);
       expect(configStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
     });
 

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -199,12 +199,7 @@ describe('org:create', () => {
         username: 'newScratchUsername',
       });
       const aliasStub = stubMethod(sandbox, Aliases.prototype, 'set');
-      const setStub = sandbox.spy();
-      const writeStub = sandbox.spy();
-      const configCreateStub = stubMethod(sandbox, Config, 'create').withArgs({ isGlobal: false }).resolves({
-        set: setStub,
-        write: writeStub,
-      });
+      const configStub = stubMethod(sandbox, Config.prototype, 'set');
       await command.runIt();
       expect(prodOrg.firstCall.args[0]).to.deep.equal({
         apiversion: undefined,
@@ -222,10 +217,7 @@ describe('org:create', () => {
         orgConfig: {},
       });
       expect(aliasStub.firstCall.args).to.deep.equal(['sandboxAlias', 'newScratchUsername']);
-      expect(configCreateStub.calledOnce).to.be.true;
-      expect(writeStub.calledOnce).to.be.true;
-      expect(configCreateStub.firstCall.firstArg).to.deep.equal({ isGlobal: false });
-      expect(setStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
+      expect(configStub.firstCall.args).to.deep.equal(['defaultusername', 'newScratchUsername']);
     });
 
     it('will test json output', async () => {

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -205,7 +205,6 @@ describe('org:create', () => {
         set: setStub,
         write: writeStub,
       });
-      // const configStub = stubMethod(sandbox, Config.prototype, 'set');
       await command.runIt();
       expect(prodOrg.firstCall.args[0]).to.deep.equal({
         apiversion: undefined,


### PR DESCRIPTION
### What does this PR do?
Tries to create local config first then falls back to global config in order to set the default username

### How to QA this:
1) if you want you can use `./bin/run` or link this plugin in sfdx by doing `sfdx plugins:link .` in the root of this folder
2) Using an org like `dreamhouse-lwc` create a new scratch org with the legacy command: `sfdx force:org:create -f config/project-scratch-def.json --setalias dreamhouse-lwc-legacy --durationdays 1 --setdefaultusername` 
3) Check out the default username with `sfdx config:list`
4) Create a new scratch org with beta command: `sfdx force:org:beta:create -f config/project-scratch-def.json --setalias dreamhouse-lwc --durationdays 1 --setdefaultusername`
5) Finally check the default username has changed with: `sfdx config:list`
### What issues does this PR fix or reference?
@W-10675890@
