### PR TITLE
Add back missing long description for "wait"

### DIFF
--- a/messages/clone.json
+++ b/messages/clone.json
@@ -12,6 +12,9 @@
     "setalias": "alias for the cloned org",
     "definitionfile": "path to the sandbox definition file"
   },
+  "flagsLong": {
+    "wait": "Sets the streaming client socket timeout, in minutes. If the streaming client socket has no contact from the server for a number of minutes, the client exits. Specify a longer wait time if timeouts occur frequently."
+  },
   "commandSuccess": "The sandbox org cloning process %s is in progress. Run \"sfdx force:org:status -n %s\" to check for status. If the org is ready, checking the status also logs the requesting user in to the sandbox org and authorizes the org for use with Salesforce CLI.",
   "missingLicenseType": "The sandbox license type is required, but you didn't provide a value.  Specify the license type in the sandbox definition file with the \"licenseType\" option, or specify the option as a name-value pair at the command-line.  See https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_sandbox_definition.htm for more information.",
   "commandOrganizationTypeNotSupport": "The only supported org type is: %s",

--- a/messages/display.json
+++ b/messages/display.json
@@ -1,10 +1,10 @@
 {
   "description": "get the description for the current or target org\nOutput includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.\nUse --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Don't share or distribute this URL or token.\nIncluding --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)",
   "examples": [
-    "sfdx force:org:display",
-    "sfdx force:org:display -u me@my.org",
-    "sfdx force:org:display -u TestOrg1 --json",
-    "sfdx force:org:display -u TestOrg1 --json > tmp/MyOrgDesc.json"
+    "$ sfdx force:org:display",
+    "$ sfdx force:org:display -u me@my.org",
+    "$ sfdx force:org:display -u TestOrg1 --json",
+    "$ sfdx force:org:display -u TestOrg1 --json > tmp/MyOrgDesc.json"
   ],
   "noScratchOrgInfoError": "No information for scratch org with ID %s found in Dev Hub %s.",
   "noScratchOrgInfoAction": "First check that you can access your Dev Hub. Then check that the ScratchOrgInfo standard object in your Dev Hub contains a record for your scratch org. In Setup, navigate to the Dev Hub page and click the Scratch Org Infos tab. If you find your scratch org, try again."

--- a/messages/list.json
+++ b/messages/list.json
@@ -1,9 +1,9 @@
 {
   "description": "list all orgs you’ve created or authenticated to",
   "examples": [
-    "sfdx force:org:list",
-    "sfdx force:org:list --verbose --json",
-    "sfdx force:org:list --verbose --json > tmp/MyOrgList.json"
+    "$ sfdx force:org:list",
+    "$ sfdx force:org:list --verbose --json",
+    "$ sfdx force:org:list --verbose --json > tmp/MyOrgList.json"
   ],
   "verbose": "list more information about each org",
   "all": "include expired, deleted, and unknown-status scratch orgs",

--- a/messages/open.json
+++ b/messages/open.json
@@ -1,11 +1,11 @@
 {
   "description": "open your default scratch org, or another specified org\nTo open a specific page, specify the portion of the URL after \"https://MyDomainName.my.salesforce.com/\" as --path.\nFor example, specify \"--path lightning\" to open Lightning Experience, or specify \"--path /apex/YourPage\" to open a Visualforce page.\nTo generate a URL but not launch it in your browser, specify --urlonly.\nTo open in a specific browser, use the --browser parameter. Supported browsers are \"chrome\", \"edge\", and \"firefox\". If you don't specify --browser, the org opens in your default browser.",
   "examples": [
-    "sfdx force:org:open",
-    "sfdx force:org:open -u me@my.org",
-    "sfdx force:org:open -u MyTestOrg1",
-    "sfdx force:org:open -r -p lightning",
-    "sfdx force:org:open -u me@my.org -b firefox"
+    "$ sfdx force:org:open",
+    "$ sfdx force:org:open -u me@my.org",
+    "$ sfdx force:org:open -u MyTestOrg1",
+    "$ sfdx force:org:open -r -p lightning",
+    "$ sfdx force:org:open -u me@my.org -b firefox"
   ],
   "browser": "browser where the org opens",
   "cliPath": "navigation URL path",

--- a/messages/status.json
+++ b/messages/status.json
@@ -1,7 +1,7 @@
 {
   "examples": [
-    "sfdx force:org:status --sandboxname DevSbx1 --setalias MySandbox -u prodOrg",
-    "sfdx force:org:status --sandboxname DevSbx1 --wait 45 --setdefaultusername -u prodOrg"
+    "$ sfdx force:org:status --sandboxname DevSbx1 --setalias MySandbox -u prodOrg",
+    "$ sfdx force:org:status --sandboxname DevSbx1 --wait 45 --setdefaultusername -u prodOrg"
   ],
   "description": "report status of sandbox creation or clone and authenticate to it\nUse this command to check the status of your sandbox creation or clone and, if the sandbox is ready, authenticate to it.\nUse the --wait (-w) parameter to specify the number of minutes that the command waits for the sandbox creation or clone to complete before returning control of the terminal to you.\nSet the --targetusername (-u) parameter to the username or alias of the production org that contains the sandbox license.",
   "flags": {

--- a/src/commands/force/org/clone.ts
+++ b/src/commands/force/org/clone.ts
@@ -58,6 +58,7 @@ export class OrgCloneCommand extends SfdxCommand {
     wait: flags.minutes({
       char: 'w',
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('flagsLong.wait'),
       min: Duration.minutes(2),
       default: Duration.minutes(6),
     }),


### PR DESCRIPTION
### What does this PR do?

Adds back a long description for "wait" that somehow got lost along the way. 

I also updated the examples so that they render correctly in the generated CLI Ref.

### What issues does this PR fix or reference?

@W-11152197@