### PR TITLE
fix: set scratch org duration to 7days by default

### DIFF
--- a/src/commands/force/org/beta/create.ts
+++ b/src/commands/force/org/beta/create.ts
@@ -90,6 +90,7 @@ export class Create extends SfdxCommand {
       description: messages.getMessage('flags.durationDays'),
       min: 1,
       max: 30,
+      default: 7,
     }),
     retry: flags.number({
       hidden: true,

--- a/test/commands/force/org/sandboxCreate.test.ts
+++ b/test/commands/force/org/sandboxCreate.test.ts
@@ -89,7 +89,7 @@ describe('org:create', () => {
     it('will warn the user when --clientid is passed', async () => {
       const commmand = await createCommand(['--type', 'sandbox', '--clientid', '123', '-u', 'testProdOrg']);
       await commmand.runIt();
-      expect(uxWarnStub.calledOnce).to.be.true;
+      expect(uxWarnStub.calledTwice).to.be.true;
       expect(uxWarnStub.firstCall.args[0]).to.equal(
         '-i | --clientid is not supported for the sandbox org create command. Its value, 123, has been ignored.'
       );
@@ -99,7 +99,7 @@ describe('org:create', () => {
     it('will warn the user when --nonamespace is passed', async () => {
       const commmand = await createCommand(['--type', 'sandbox', '--nonamespace', '-u', 'testProdOrg']);
       await commmand.runIt();
-      expect(uxWarnStub.calledOnce).to.be.true;
+      expect(uxWarnStub.calledTwice).to.be.true;
       expect(uxWarnStub.firstCall.args[0]).to.equal(
         '-n | --nonamespace is not supported for the sandbox org create command. Its value, true, has been ignored.'
       );
@@ -108,7 +108,7 @@ describe('org:create', () => {
     it('will warn the user when --noancestors is passed', async () => {
       const commmand = await createCommand(['--type', 'sandbox', '--noancestors', '-u', 'testProdOrg']);
       await commmand.runIt();
-      expect(uxWarnStub.calledOnce).to.be.true;
+      expect(uxWarnStub.calledTwice).to.be.true;
       expect(uxWarnStub.firstCall.args[0]).to.equal(
         '-c | --noancestors is not supported for the sandbox org create command. Its value, true, has been ignored.'
       );

--- a/test/commands/force/org/scratchOrgCreate.test.ts
+++ b/test/commands/force/org/scratchOrgCreate.test.ts
@@ -112,7 +112,7 @@ describe('org:create', () => {
         apiversion: undefined,
         clientSecret: undefined,
         connectedAppConsumerKey: undefined,
-        durationDays: undefined,
+        durationDays: 7,
         noancestors: undefined,
         nonamespace: undefined,
         wait: {
@@ -165,7 +165,7 @@ describe('org:create', () => {
         clientSecret,
         connectedAppConsumerKey,
         definitionfile,
-        durationDays: undefined,
+        durationDays: 7,
         noancestors: undefined,
         nonamespace: undefined,
         wait: {
@@ -216,7 +216,7 @@ describe('org:create', () => {
         clientSecret: undefined,
         connectedAppConsumerKey: undefined,
         definitionfile,
-        durationDays: undefined,
+        durationDays: 7,
         noancestors: undefined,
         nonamespace: undefined,
         wait: {
@@ -268,7 +268,7 @@ describe('org:create', () => {
         clientSecret: undefined,
         connectedAppConsumerKey: undefined,
         definitionfile,
-        durationDays: undefined,
+        durationDays: 7,
         noancestors: undefined,
         nonamespace: undefined,
         wait: {
@@ -299,7 +299,7 @@ describe('org:create', () => {
         clientSecret: undefined,
         connectedAppConsumerKey: undefined,
         definitionfile,
-        durationDays: undefined,
+        durationDays: 7,
         noancestors: undefined,
         nonamespace: undefined,
         wait: {


### PR DESCRIPTION
### What does this PR do?

Sets `durationdays` flag value to 7 days by default for `force:org:beta:create`, this matches the current org create command from toolbelt.

## Before
the flag value was being passed as undefined to the scratch org payload, then the API would set the duration to 1 day.

## After
if `--durationdays` isn't passed org:beta:create will default to 7 days.

### What issues does this PR fix or reference?
@W-0@