### PR TITLE
test: remove deprecated querystring

### DIFF
--- a/test/nut/commands/force/org/org.nut.ts
+++ b/test/nut/commands/force/org/org.nut.ts
@@ -6,7 +6,6 @@
  */
 
 import { join } from 'path';
-import * as querystring from 'querystring';
 import { expect, config } from 'chai';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
@@ -184,7 +183,7 @@ describe('Org Command NUT', () => {
       expect(result).to.include({ orgId: aliasUserOrgId, username: aliasedUsername });
       expect(result)
         .to.property('url')
-        .to.include(`retURL=${querystring.escape('foo/bar/baz')}`);
+        .to.include(`retURL=${encodeURIComponent(decodeURIComponent('foo/bar/baz'))}`);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
NUT matches what the command's flag.parse is using for urlencoding the path

This seems to work in this repo's NUTs (encodes), and work locally (encodes) but fails on just-nuts (no encoding).
https://github.com/salesforcecli/sfdx-cli/actions/runs/3491014374/jobs/5843317166

** I have no idea why! **

The goal of this PR is that whatever differences may exist at runtime, they match.

### What issues does this PR fix or reference?
[@W-12084293@](https://gus.lightning.force.com/a07EE00001DUJmwYAH)