### PR TITLE
edit messages for sf-ied plugin-org commands

### DIFF
--- a/messages/clone.md
+++ b/messages/clone.md
@@ -1,10 +1,13 @@
+# summary
+
+Clone a sandbox org.
+
 # success
 
 The sandbox org cloning process %s is in progress. Run "sfdx force:org:status -n %s" to check for status. If the org is ready, checking the status also logs the requesting user in to the sandbox org and authorizes the org for use with Salesforce CLI.
 
 # description
 
-clone a sandbox org
 There are two ways to clone a sandbox: either specify a sandbox definition file or provide key=value pairs at the command line. Key-value pairs at the command-line override their equivalent sandbox definition file values. In either case, you must specify both the "SandboxName" and "SourceSandboxName" options to set the names of the new sandbox and the one being cloned, respectively.
 
 Set the --targetusername (-u) parameter to a production org with sandbox licenses. The --type (-t) parameter is required and must be set to "sandbox".
@@ -17,23 +20,23 @@ Set the --targetusername (-u) parameter to a production org with sandbox license
 
 # flags.type
 
-type of org to create
+Type of org to create.
 
 # flags.wait
 
-number of minutes to wait while polling for status
+Number of minutes to wait while polling for status.
 
 # flags.setdefaultusername
 
-set the cloned org as your default
+Set the cloned org as your default.
 
 # flags.setalias
 
-alias for the cloned org
+Alias for the cloned org.
 
 # flags.definitionfile
 
-path to the sandbox definition file
+Path to the sandbox definition file.
 
 # flagsLong.wait
 

--- a/messages/create.md
+++ b/messages/create.md
@@ -8,7 +8,6 @@ The force:org:create command is deprecated. Use org:create:scratch or org:create
 
 # description
 
-create a scratch or sandbox org
 Creates a scratch org or a sandbox org using the values specified in a configuration file or key=value pairs that you specify on the command line. Values specified on the command line override values in the configuration file. Specify a configuration file or provide key=value pairs while creating a scratch org or a sandbox. When creating scratch orgs, —targetdevhubusername (-v) must be a Dev Hub org. When creating sandboxes, the --targetusername (-u) must be a production org with sandbox licenses. The —type (-t) is required if creating a sandbox.
 
 # examples
@@ -23,43 +22,43 @@ Creates a scratch org or a sandbox org using the values specified in a configura
 
 # flags.clientId
 
-connected app consumer key; not supported for sandbox org creation
+Connected app consumer key; not supported for sandbox org creation.
 
 # flags.setDefaultUsername
 
-set the created org as the default username
+Set the created org as the default username.
 
 # flags.setAlias
 
-alias for the created org
+Alias for the created org.
 
 # flags.definitionFile
 
-path to an org definition file
+Path to an org definition file.
 
 # flags.definitionJson
 
-org definition in JSON format
+Org definition in JSON format.
 
 # flags.noNamespace
 
-create the scratch org with no namespace
+Create the scratch org with no namespace.
 
 # flags.noAncestors
 
-do not include second-generation package ancestors in the scratch org
+Do not include second-generation package ancestors in the scratch org.
 
 # flags.env
 
-environment where the scratch org is created: %s
+Environment where the scratch org is created: %s.
 
 # flags.type
 
-type of org to create
+Type of org to create.
 
 # flags.durationDays
 
-duration of the scratch org (in days) (default:7, min:1, max:30)
+Duration of the scratch org (in days) (default:7, min:1, max:30).
 
 # flags.retry
 
@@ -67,7 +66,7 @@ Number of scratch org auth retries after scratch org is successfully signed up.
 
 # flags.wait
 
-the streaming client socket timeout (in minutes)
+Streaming client socket timeout (in minutes).
 
 # scratchOrgCreateSuccess
 

--- a/messages/delete.md
+++ b/messages/delete.md
@@ -1,6 +1,6 @@
 # summary
 
-Delete a scratch org or sandbox.
+Delete a scratch or sandbox org.
 
 # deprecation
 
@@ -8,7 +8,8 @@ The force:org:delete command is deprecated. Use org:delete:scratch or org:delete
 
 # description
 
-mark a scratch or sandbox org for deletion
+Deleting a scratch or sandbox org is a two-part process. Salesforce CLI first deletes all local references to the org from your computer. It then it marks the org for deletion in either the Dev Hub org (for scratch orgs) or production org (for sandboxes.)
+
 To mark the org for deletion without being prompted to confirm, specify --noprompt.
 
 # examples
@@ -19,7 +20,7 @@ To mark the org for deletion without being prompted to confirm, specify --noprom
 
 # flags.noprompt
 
-no prompt to confirm deletion
+No prompt to confirm deletion.
 
 # confirmDelete
 

--- a/messages/delete_sandbox.md
+++ b/messages/delete_sandbox.md
@@ -4,6 +4,8 @@ Delete a sandbox.
 
 # description
 
+Deleting a sandbox org is a two-part process. Salesforce CLI first deletes all local references to the org from your computer. It then it marks the org for deletion in the production org that contains the sandbox licenses.
+
 Specify a sandbox with either the username you used when you logged into it with "sf login", or the alias you gave the sandbox when you created it. Run "sf env list" to view all your environments, including sandboxes, and their aliases.
 
 # examples

--- a/messages/delete_scratch.md
+++ b/messages/delete_scratch.md
@@ -4,6 +4,8 @@ Delete a scratch org.
 
 # description
 
+Deleting a scratch org is a two-part process. Salesforce CLI first deletes all local references to the org from your computer. It then it marks the org for deletion in the Dev Hub org.
+
 Specify a scratch org with either the username you used when you logged into it with "sf login", or the alias you gave the scratch org when you created it. Run "sf env list" to view all your environments, including scratch orgs, and their aliases.
 
 # examples

--- a/messages/display.md
+++ b/messages/display.md
@@ -1,27 +1,28 @@
 # summary
 
-display information about an org
+Display information about an org.
 
 # description
 
-get the description for the current or target org
 Output includes your access token, client Id, connected status, org ID, instance URL, username, and alias, if applicable.
+
 Use --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Don't share or distribute this URL or token.
-Including --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant)
 
-# flags.verbose
+Including --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant).
 
-display the sfdxAuthUrl property
+# flags.verbose.summary
+
+Display the sfdxAuthUrl property.
 
 # examples
 
-- $ <%= config.bin %> <%= command.id %>
+- Display information about your default org:
 
-- $ <%= config.bin %> <%= command.id %> -u me@my.org
+  $ <%= config.bin %> <%= command.id %>
 
-- $ <%= config.bin %> <%= command.id %> -u TestOrg1 --json
+- Display information, including the sfdxAuthUrl property, about the org with alias TestOrg1:
 
-- $ <%= config.bin %> <%= command.id %> -u TestOrg1 --json > tmp/MyOrgDesc.json
+  $ <%= config.bin %> <%= command.id %> --target-org TestOrg1 --verbose
 
 # noScratchOrgInfoError
 

--- a/messages/list.md
+++ b/messages/list.md
@@ -1,34 +1,40 @@
-# description
+# summary
 
-list all orgs you’ve created or authenticated to
+List all orgs you’ve created or authenticated to.
 
 # examples
 
-- $ <%= config.bin %> <%= command.id %>
+- List all orgs you've created or authenticated to:
 
-- $ <%= config.bin %> <%= command.id %> --verbose --json
+  $ <%= config.bin %> <%= command.id %>
 
-- $ <%= config.bin %> <%= command.id %> --verbose --json > tmp/MyOrgList.json
+- List all orgs, including expired, deleted, and unknown-status orgs; don't include the connection status:
 
-# verbose
+  $ <%= config.bin %> <%= command.id %> --skip-connection-status --all
 
-list more information about each org
+- List orgs and remove local org authorization info about non-active scratch orgs:
 
-# all
+  $ <%= config.bin %> <%= command.id %> --clean
 
-include expired, deleted, and unknown-status scratch orgs
+# flags.verbose.summary
 
-# clean
+List more information about each org.
 
-remove all local org authorizations for non-active scratch orgs. Use auth:logout to remove non-scratch orgs
+# flags.all.summary
 
-# noPrompt
+Include expired, deleted, and unknown-status scratch orgs.
 
-do not prompt for confirmation
+# flags.clean.summary
 
-# skipConnectionStatus
+Remove all local org authorizations for non-active scratch orgs. Use auth:logout to remove non-scratch orgs.
 
-skip retrieving the connection status of non-scratch orgs
+# flags.noPrompt.summary
+
+Don't prompt for confirmation.
+
+# flags.skipConnectionStatus.summary
+
+Skip retrieving the connection status of non-scratch orgs.
 
 # prompt
 
@@ -36,7 +42,7 @@ Found (%s) org configurations to delete. Are you sure (yes/no)?
 
 # noActiveScratchOrgs
 
-No active scratch orgs found. Specify --all to see all scratch orgs
+No active scratch orgs found. Specify --all to see all scratch orgs.
 
 # deleteOrgs
 

--- a/messages/open.md
+++ b/messages/open.md
@@ -1,34 +1,40 @@
+# summary
+
+Open your default scratch org, or another specified org, in a browser.
+
 # description
 
-open your default scratch org, or another specified org
-To open a specific page, specify the portion of the URL after "https://MyDomainName.my.salesforce.com/" as --path.
-For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
-To generate a URL but not launch it in your browser, specify --urlonly.
-To open in a specific browser, use the --browser parameter. Supported browsers are "chrome", "edge", and "firefox". If you don't specify --browser, the org opens in your default browser.
+To open a specific page, specify the portion of the URL after "https://MyDomainName.my.salesforce.com/" as the value for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
+
+To generate a URL but not launch it in your browser, specify --url-only.
+
+To open in a specific browser, use the --browser flag. Supported browsers are "chrome", "edge", and "firefox". If you don't specify --browser, the org opens in your default browser.
 
 # examples
 
-- $ <%= config.bin %> <%= command.id %>
+- Open your default org in your default browser:
 
-- $ <%= config.bin %> <%= command.id %> -u me@my.org
+  $ <%= config.bin %> <%= command.id %>
 
-- $ <%= config.bin %> <%= command.id %> -u MyTestOrg1
+- Open the org with alias MyTestOrg1 in the Firefox browser:
 
-- $ <%= config.bin %> <%= command.id %> -r -p lightning
+  $ <%= config.bin %> <%= command.id %> --target-org MyTestOrg1 --browser firefox
 
-- $ <%= config.bin %> <%= command.id %> -u me@my.org -b firefox
+- Display the navigation URL for the Lightning Experience page for your default org, but don't open the page in a browser:
 
-# browser
+  $ <%= config.bin %> <%= command.id %> --url-only --path lightning
 
-browser where the org opens
+# flags.browser.summary
 
-# cliPath
+Browser where the org opens.
 
-navigation URL path
+# flags.path.summary
 
-# urlonly
+Navigation URL path to open a specific page.
 
-display navigation URL, but don’t launch browser
+# flags.url-only.summary
+
+Display navigation URL, but don’t launch browser.
 
 # containerAction
 

--- a/messages/status.md
+++ b/messages/status.md
@@ -10,23 +10,24 @@ Check the status of a sandbox, and if complete, authenticate to it.
 
 # description
 
-report status of sandbox creation or clone and authenticate to it
 Use this command to check the status of your sandbox creation or clone and, if the sandbox is ready, authenticate to it.
+
 Use the --wait (-w) parameter to specify the number of minutes that the command waits for the sandbox creation or clone to complete before returning control of the terminal to you.
-Set the --targetusername (-u) parameter to the username or alias of the production org that contains the sandbox license.
+
+Set the --target-org (-o) parameter to the username or alias of the production org that contains the sandbox license.
 
 # flags.sandboxname
 
-name of the sandbox org to check status for
+Name of the sandbox org to check status for.
 
 # flags.wait
 
-number of minutes to wait while polling for status
+Number of minutes to wait while polling for status.
 
 # flags.setdefaultusername
 
-set the created or cloned org as your default
+Set the created or cloned org as your default.
 
 # flags.setalias
 
-alias for the created or cloned org
+Alias for the created or cloned org.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@salesforce/cli-plugins-testkit": "^3.2.18",
     "@salesforce/dev-config": "^3.1.0",
     "@salesforce/dev-scripts": "^4.0.0-beta.7",
-    "@salesforce/plugin-command-reference": "^2.2.8",
+    "@salesforce/plugin-command-reference": "^2.2.9",
     "@salesforce/prettier-config": "^0.0.2",
     "@salesforce/ts-sinon": "1.4.2",
     "@swc/core": "^1.3.24",

--- a/src/commands/force/org/clone.ts
+++ b/src/commands/force/org/clone.ts
@@ -35,7 +35,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-org', 'clone');
 
 export class OrgCloneCommand extends SfCommand<SandboxProcessObject> {
   public static readonly examples = messages.getMessages('examples');
-  public static readonly summary = messages.getMessage('description');
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly strict = false;
   public static state = 'deprecated';

--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -22,7 +22,7 @@ export type DeleteResult = {
 };
 
 export class Delete extends SfCommand<DeleteResult> {
-  public static readonly summary = messages.getMessage('description');
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static state = 'deprecated';

--- a/src/commands/org/display.ts
+++ b/src/commands/org/display.ts
@@ -33,7 +33,7 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     verbose: Flags.boolean({
-      summary: messages.getMessage('flags.verbose'),
+      summary: messages.getMessage('flags.verbose.summary'),
     }),
     loglevel,
   };

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -20,30 +20,29 @@ export type OrgListResult = {
   scratchOrgs: FullyPopulatedScratchOrgFields[];
 };
 export class OrgListCommand extends SfCommand<OrgListResult> {
-  public static readonly summary = messages.getMessage('description');
-  public static readonly description = messages.getMessage('description');
+  public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static aliases = ['force:org:list'];
   public static deprecateAliases = true;
   public static readonly flags = {
     verbose: Flags.boolean({
-      summary: messages.getMessage('verbose'),
+      summary: messages.getMessage('flags.verbose.summary'),
     }),
     all: Flags.boolean({
-      summary: messages.getMessage('all'),
+      summary: messages.getMessage('flags.all.summary'),
     }),
     clean: Flags.boolean({
-      summary: messages.getMessage('clean'),
+      summary: messages.getMessage('flags.clean.summary'),
     }),
     'no-prompt': Flags.boolean({
       char: 'p',
-      summary: messages.getMessage('noPrompt'),
+      summary: messages.getMessage('flags.noPrompt.summary'),
       dependsOn: ['clean'],
       aliases: ['noprompt'],
       deprecateAliases: true,
     }),
     'skip-connection-status': Flags.boolean({
-      summary: messages.getMessage('skipConnectionStatus'),
+      summary: messages.getMessage('flags.skipConnectionStatus.summary'),
       aliases: ['skipconnectionstatus'],
       deprecateAliases: true,
     }),

--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -22,7 +22,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-org', 'open');
 const sharedMessages = Messages.loadMessages('@salesforce/plugin-org', 'messages');
 
 export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
-  public static readonly summary = messages.getMessage('description');
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:open'];
@@ -33,19 +33,19 @@ export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
     'api-version': orgApiVersionFlagWithDeprecations,
     browser: Flags.string({
       char: 'b',
-      summary: messages.getMessage('browser'),
+      summary: messages.getMessage('flags.browser.summary'),
       options: ['chrome', 'edge', 'firefox'], // These are ones supported by "open" package
       exclusive: ['url-only'],
     }),
     path: Flags.string({
       char: 'p',
-      summary: messages.getMessage('cliPath'),
+      summary: messages.getMessage('flags.path.summary'),
       env: 'FORCE_OPEN_URL',
       parse: (input: string): Promise<string> => Promise.resolve(encodeURIComponent(decodeURIComponent(input))),
     }),
     'url-only': Flags.boolean({
       char: 'r',
-      summary: messages.getMessage('urlonly'),
+      summary: messages.getMessage('flags.url-only.summary'),
       aliases: ['urlonly'],
       deprecateAliases: true,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,7 +699,7 @@
     is-wsl "^2.1.1"
     tslib "^2.3.1"
 
-"@oclif/core@^1.20.3", "@oclif/core@^1.20.4", "@oclif/core@^1.21.0", "@oclif/core@^1.23.0", "@oclif/core@^1.23.1", "@oclif/core@^1.6.3":
+"@oclif/core@^1.20.3", "@oclif/core@^1.20.4", "@oclif/core@^1.21.0", "@oclif/core@^1.23.0", "@oclif/core@^1.23.1":
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.23.1.tgz#bebbbc4e02a4c1a4216d64165f892037f8a1e14a"
   integrity sha512-nz7wVGesJ1Qg74p1KNKluZpQ3Z042mqdaRlczEI4Xwqj5s9jjdDBCDHNkiGzV4UAKzicVzipNj6qqhyUWKYnaA==
@@ -999,7 +999,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^3.32.12", "@salesforce/core@^3.33.1", "@salesforce/core@^3.8.0":
+"@salesforce/core@^3.32.12", "@salesforce/core@^3.33.1":
   version "3.33.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.33.1.tgz#3dd0a44ba22763e8e0c2c97df03393e5c2c845d9"
   integrity sha512-jaed8rK+NhSxB6MjYUN8f/2VkvtbFN/Ce/l6JvgFE+cvOf2g+lPv1pSsnKKlaSiiYcXkOvIRDT9d9ns1RLJzUw==
@@ -1067,7 +1067,7 @@
     typescript "^4.1.3"
     wireit "^0.9.3"
 
-"@salesforce/kit@^1.5.17", "@salesforce/kit@^1.7.1", "@salesforce/kit@^1.8.0", "@salesforce/kit@^1.8.2":
+"@salesforce/kit@^1.7.1", "@salesforce/kit@^1.8.0", "@salesforce/kit@^1.8.2":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.2.tgz#97d652bef37d02a13dffd6e9b68050e779db2bc4"
   integrity sha512-UoY1bgWjw198QMyLKYXlF1bdqBqVtffBgtIT1M/cEwBF/Es1Oz3HaF1TwF98CmyC1dr6rL08Hr2SE5zHGijcLw==
@@ -1076,16 +1076,25 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/plugin-command-reference@^2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-command-reference/-/plugin-command-reference-2.2.8.tgz#b75571df46ad5210ce5170cb42de57cd6965ff84"
-  integrity sha512-vyJzYDOGDmF3NyVhdRwLNkM+lVj3pzwbusHq4eGJDsxrlgWALeg0IVbEeEI+qUk32BK/wpwcJNbPRTc4Bem36w==
+"@salesforce/kit@^1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.3.tgz#b590b78a8618494c51534598a7eb0683ba0da3f2"
+  integrity sha512-p+0tWR2pyCAIjZwDXGhrYFPuLckX9fP3Xa6Jync9POeQBfDGyK9CRd1eaiWj+6BeDS9kwvgm5M6o+OptIEhEjw==
   dependencies:
-    "@oclif/core" "^1.6.3"
-    "@salesforce/core" "^3.8.0"
-    "@salesforce/kit" "^1.5.17"
-    "@salesforce/sf-plugins-core" "^1.9.0"
-    "@salesforce/ts-types" "^1.5.20"
+    "@salesforce/ts-types" "^1.7.2"
+    shx "^0.3.3"
+    tslib "^2.2.0"
+
+"@salesforce/plugin-command-reference@^2.2.9":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-command-reference/-/plugin-command-reference-2.2.10.tgz#6e4678bb768487ad8af04a6271da71a953b4bbe2"
+  integrity sha512-+0onzNeiQ/JoKYWPrMxbo7XTSVkMeNrCFSN1LL/w4QOQFjQUAKr+EyyYiEJp0QrgdppmuCanCELPhA2mlKNpiw==
+  dependencies:
+    "@oclif/core" "^1.23.1"
+    "@salesforce/core" "^3.32.12"
+    "@salesforce/kit" "^1.8.2"
+    "@salesforce/sf-plugins-core" "^1.21.5"
+    "@salesforce/ts-types" "^1.7.1"
     chalk "^3.0.0"
     fs-extra "^10.0.1"
     handlebars "^4.7.7"
@@ -1103,7 +1112,19 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.4.0.tgz#7dff427c8059895d8108176047aee600703c82d6"
   integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
 
-"@salesforce/sf-plugins-core@^1.22.1", "@salesforce/sf-plugins-core@^1.9.0":
+"@salesforce/sf-plugins-core@^1.21.5":
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-1.22.2.tgz#56aa9c490a64a53142160eb0b67bc32331ad0674"
+  integrity sha512-T6TsDoj5DzZTW5XvggbCropfAB3V88V48dzcZU2vsy5zI6ZQdHVO0xa6T5ylJAvuyOrmmtkVq3wlwoQj9Jz+ow==
+  dependencies:
+    "@oclif/core" "^1.23.1"
+    "@salesforce/core" "^3.32.12"
+    "@salesforce/kit" "^1.8.3"
+    "@salesforce/ts-types" "^1.7.1"
+    chalk "^4"
+    inquirer "^8.2.5"
+
+"@salesforce/sf-plugins-core@^1.22.1":
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-1.22.1.tgz#58c445aa8c72ae7ddd6ec39269ae1d944d059e9b"
   integrity sha512-UAAi7I753+t9zVJDHMzk81XCsYU5q2kq7aSgFbokdvnnPx45i3NptyaKNCRDeOBxp3eYCuNG6iFZ+xzC+v8cfA==
@@ -1124,7 +1145,7 @@
     sinon "^5.1.1"
     tslib "^2.2.0"
 
-"@salesforce/ts-types@^1.5.20", "@salesforce/ts-types@^1.7.1", "@salesforce/ts-types@^1.7.2":
+"@salesforce/ts-types@^1.7.1", "@salesforce/ts-types@^1.7.2":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.2.tgz#ab40399d291c7eca57efc9890daf2fa2632197ec"
   integrity sha512-eCpWKEb03UCKBJ6Svp0Vwcwt+fG6BQbopO4x5wt6CYeT8Rjt0dbDQicZPmVL59j2qyt3Q4Y4EYsxXUGZmdfvDw==


### PR DESCRIPTION
### What does this PR do?

Edits/improves messages for the various "org" commands.  I didn't do much with the help for the deprecated commands (force:org:clone|create|delete|status).  

NOTE that I upped the version (2.2.9) of plugin-command-reference in package.json so it wouldn't complain about missing (yet optional) command descriptions.  I also then checked in a new yarn.lock file.  I _think_ this is what I'm supposed to do, but if not... sorry.  

### What issues does this PR fix or reference?

@W-12422237@
