### PR TITLE
fix: restore hub flag on org:delete

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -40,7 +40,7 @@
   {
     "command": "force:org:delete",
     "plugin": "@salesforce/plugin-org",
-    "flags": ["api-version", "json", "loglevel", "no-prompt", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "no-prompt", "target-org", "targetdevhubusername"],
     "alias": []
   },
   {

--- a/messages/delete.md
+++ b/messages/delete.md
@@ -22,6 +22,10 @@ To mark the org for deletion without being prompted to confirm, specify --noprom
 
 No prompt to confirm deletion.
 
+# flags.targetdevhubusername
+
+The targetdevhubusername flag exists only for backwards compatibility. It is not necessary and has no effect.
+
 # confirmDelete
 
 Enqueue %s org with name: %s for deletion? Are you sure (y/n)?

--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -31,6 +31,15 @@ export class Delete extends SfCommand<DeleteResult> {
   };
   public static readonly flags = {
     'target-org': requiredOrgFlagWithDeprecations,
+    targetdevhubusername: Flags.string({
+      summary: messages.getMessage('flags.targetdevhubusername'),
+      char: 'v',
+      hidden: true,
+      deprecated: {
+        version: '58.0',
+        message: messages.getMessage('flags.targetdevhubusername'),
+      },
+    }),
     'api-version': orgApiVersionFlagWithDeprecations,
     'no-prompt': Flags.boolean({
       char: 'p',


### PR DESCRIPTION
### What does this PR do?

We deleted an unused flag.  This puts a hidden, dummy string flag in its place to avoid breaking changes.  It'll include warnings for anyone who uses it (the entire command is deprecated anyway).

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1925
[@W-12563970@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001LRZwyYAH/view)
