### PR TITLE
fix: remove beta tag from org commands

### DIFF
--- a/src/commands/org/create/sandbox.ts
+++ b/src/commands/org/create/sandbox.ts
@@ -116,7 +116,6 @@ export default class CreateSandbox extends SandboxCommandBase<SandboxProcessObje
       allowNo: false,
     }),
   };
-  public static readonly state = 'beta';
   private flags!: Interfaces.InferredFlags<typeof CreateSandbox.flags>;
 
   public async run(): Promise<SandboxProcessObject> {

--- a/src/commands/org/create/scratch.ts
+++ b/src/commands/org/create/scratch.ts
@@ -31,7 +31,6 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['env:create:scratch'];
   public static readonly deprecateAliases = true;
-  public static readonly state = 'beta';
 
   public static readonly flags = {
     alias: Flags.string({

--- a/src/commands/org/delete/sandbox.ts
+++ b/src/commands/org/delete/sandbox.ts
@@ -31,7 +31,6 @@ export default class EnvDeleteSandbox extends SfCommand<SandboxDeleteResponse> {
       summary: messages.getMessage('flags.no-prompt.summary'),
     }),
   };
-  public static readonly state = 'beta';
 
   public async run(): Promise<SandboxDeleteResponse> {
     const flags = (await this.parse(EnvDeleteSandbox)).flags;

--- a/src/commands/org/delete/scratch.ts
+++ b/src/commands/org/delete/scratch.ts
@@ -33,7 +33,6 @@ export default class EnvDeleteScratch extends SfCommand<ScratchDeleteResponse> {
       summary: messages.getMessage('flags.no-prompt.summary'),
     }),
   };
-  public static readonly state = 'beta';
 
   public async run(): Promise<ScratchDeleteResponse> {
     const flags = (await this.parse(EnvDeleteScratch)).flags;

--- a/src/commands/org/resume/sandbox.ts
+++ b/src/commands/org/resume/sandbox.ts
@@ -70,7 +70,6 @@ export default class ResumeSandbox extends SandboxCommandBase<SandboxProcessObje
       description: messages.getMessage('flags.targetOrg.description'),
     }),
   };
-  public static readonly state = 'beta';
   private flags!: Interfaces.InferredFlags<typeof ResumeSandbox.flags>;
 
   public async run(): Promise<SandboxProcessObject> {


### PR DESCRIPTION
### What does this PR do?
Removes beta tag from org commands.
Users running the deprecated commands get a warn to use the new commands, but these are still marked as beta.

See: https://twitter.com/JHMSchwarzer/status/1626930091811868672

### What issues does this PR fix or reference?
@W-0@