### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -26,7 +26,7 @@ export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:open'];
-  public static depreprecateAliases = true;
+  public static deprecateAliases = true;
 
   public static readonly flags = {
     'target-org': requiredOrgFlagWithDeprecations,


### PR DESCRIPTION
### What does this PR do?
I noticed that `force org open` was not showing a command deprecation warning. This PR fixes a typo and it now shows
<img width="996" alt="Screenshot 2023-03-14 at 11 28 45 AM" src="https://user-images.githubusercontent.com/1715111/225073395-5f6aedad-424e-464a-be9d-497ff81b1726.png">

### What issues does this PR fix or reference?
[skip-validate-pr]