### PR TITLE
fix: can delete default being an alias

### DIFF
--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -55,9 +55,12 @@ export class Delete extends SfCommand<DeleteResult> {
   public async run(): Promise<DeleteResult> {
     const { flags } = await this.parse(Delete);
     const resolvedUsername =
-      // from -o alias -> -o username -> [default username]
+      // from -o alias -> -o username -> [default username resolved an alias] -> [default username]
       (await StateAggregator.getInstance()).aliases.getUsername(flags['target-org'] ?? '') ??
       flags['target-org'] ??
+      (await StateAggregator.getInstance()).aliases.getUsername(
+        this.configAggregator.getPropertyValue('target-org') as string
+      ) ??
       (this.configAggregator.getPropertyValue('target-org') as string);
 
     if (!resolvedUsername) {

--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -6,6 +6,7 @@
  */
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { AuthInfo, AuthRemover, Messages, Org, StateAggregator } from '@salesforce/core';
+import { orgThatMightBeDeleted } from '../../../shared/flags';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete');
@@ -24,13 +25,8 @@ export class Delete extends SfCommand<DeleteResult> {
     message: messages.getMessage('deprecation'),
   };
   public static readonly flags = {
-    'target-org': Flags.string({
-      // not required because the user could be assuming the default config
-      aliases: ['targetusername', 'u'],
-      deprecateAliases: true,
-      // we're recreating the flag without all the validation
-      // eslint-disable-next-line sf-plugin/dash-o
-      char: 'o',
+    'target-org': orgThatMightBeDeleted({
+      required: true,
       summary: messages.getMessage('flags.target-org.summary'),
     }),
     targetdevhubusername: Flags.string({
@@ -54,18 +50,7 @@ export class Delete extends SfCommand<DeleteResult> {
 
   public async run(): Promise<DeleteResult> {
     const { flags } = await this.parse(Delete);
-    const resolvedUsername =
-      // from -o alias -> -o username -> [default username resolved an alias] -> [default username]
-      (await StateAggregator.getInstance()).aliases.getUsername(flags['target-org'] ?? '') ??
-      flags['target-org'] ??
-      (await StateAggregator.getInstance()).aliases.getUsername(
-        this.configAggregator.getPropertyValue('target-org') as string
-      ) ??
-      (this.configAggregator.getPropertyValue('target-org') as string);
-
-    if (!resolvedUsername) {
-      throw messages.createError('missingUsername');
-    }
+    const resolvedUsername = flags['target-org'];
 
     const orgId = (await AuthInfo.create({ username: resolvedUsername })).getFields().orgId as string;
     const isSandbox = await (await StateAggregator.getInstance()).sandboxes.hasFile(orgId);

--- a/src/commands/org/delete/sandbox.ts
+++ b/src/commands/org/delete/sandbox.ts
@@ -37,9 +37,13 @@ export default class EnvDeleteSandbox extends SfCommand<SandboxDeleteResponse> {
 
   public async run(): Promise<SandboxDeleteResponse> {
     const flags = (await this.parse(EnvDeleteSandbox)).flags;
-    const username = // from -o alias -> -o username -> [default username]
+    const username =
+      // from -o alias -> -o username -> [default username resolved an alias] -> [default username]
       (await StateAggregator.getInstance()).aliases.getUsername(flags['target-org'] ?? '') ??
       flags['target-org'] ??
+      (await StateAggregator.getInstance()).aliases.getUsername(
+        this.configAggregator.getPropertyValue('target-org') as string
+      ) ??
       (this.configAggregator.getPropertyValue('target-org') as string);
     if (!username) {
       throw new SfError('The org does not have a username.');

--- a/src/commands/org/delete/scratch.ts
+++ b/src/commands/org/delete/scratch.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthInfo, AuthRemover, Messages, Org, StateAggregator } from '@salesforce/core';
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete_scratch');
@@ -41,9 +41,12 @@ export default class EnvDeleteScratch extends SfCommand<ScratchDeleteResponse> {
   public async run(): Promise<ScratchDeleteResponse> {
     const flags = (await this.parse(EnvDeleteScratch)).flags;
     const resolvedUsername =
-      // from -o alias -> -o username -> [default username]
+      // from -o alias -> -o username -> [default username resolved an alias] -> [default username]
       (await StateAggregator.getInstance()).aliases.getUsername(flags['target-org'] ?? '') ??
       flags['target-org'] ??
+      (await StateAggregator.getInstance()).aliases.getUsername(
+        this.configAggregator.getPropertyValue('target-org') as string
+      ) ??
       (this.configAggregator.getPropertyValue('target-org') as string);
     const orgId = (await AuthInfo.create({ username: resolvedUsername })).getFields().orgId as string;
 

--- a/src/commands/org/delete/scratch.ts
+++ b/src/commands/org/delete/scratch.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, AuthRemover, Messages, Org, StateAggregator } from '@salesforce/core';
+import { AuthInfo, AuthRemover, Messages, Org } from '@salesforce/core';
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
+import { orgThatMightBeDeleted } from '../../../shared/flags';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete_scratch');
@@ -23,14 +24,9 @@ export default class EnvDeleteScratch extends SfCommand<ScratchDeleteResponse> {
   public static readonly aliases = ['env:delete:scratch'];
   public static readonly deprecateAliases = true;
   public static readonly flags = {
-    'target-org': Flags.string({
-      // not required because the user could be assuming the default config
-      aliases: ['targetusername', 'u'],
-      deprecateAliases: true,
-      // we're recreating the flag without all the validation
-      // eslint-disable-next-line sf-plugin/dash-o
-      char: 'o',
+    'target-org': orgThatMightBeDeleted({
       summary: messages.getMessage('flags.target-org.summary'),
+      required: true,
     }),
     'no-prompt': Flags.boolean({
       char: 'p',
@@ -40,14 +36,7 @@ export default class EnvDeleteScratch extends SfCommand<ScratchDeleteResponse> {
 
   public async run(): Promise<ScratchDeleteResponse> {
     const flags = (await this.parse(EnvDeleteScratch)).flags;
-    const resolvedUsername =
-      // from -o alias -> -o username -> [default username resolved an alias] -> [default username]
-      (await StateAggregator.getInstance()).aliases.getUsername(flags['target-org'] ?? '') ??
-      flags['target-org'] ??
-      (await StateAggregator.getInstance()).aliases.getUsername(
-        this.configAggregator.getPropertyValue('target-org') as string
-      ) ??
-      (this.configAggregator.getPropertyValue('target-org') as string);
+    const resolvedUsername = flags['target-org'];
     const orgId = (await AuthInfo.create({ username: resolvedUsername })).getFields().orgId as string;
 
     if (flags['no-prompt'] || (await this.confirm(messages.getMessage('prompt.confirm', [resolvedUsername])))) {

--- a/src/shared/flags.ts
+++ b/src/shared/flags.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Flags } from '@oclif/core';
+import { ConfigAggregator, StateAggregator, Messages, SfError } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete');
+
+const resolveUsername = async (usernameOrAlias?: string): Promise<string> => {
+  const stateAggregator = await StateAggregator.getInstance();
+  // we have a value, but don't know if it's a username or an alias
+  if (usernameOrAlias) return stateAggregator.aliases.resolveUsername(usernameOrAlias);
+  // we didn't get a value, so let's see if the config has a default target org
+  const configAggregator = await ConfigAggregator.create();
+  const defaultUsernameOrAlias = configAggregator.getPropertyValue('target-org') as string | undefined;
+  if (defaultUsernameOrAlias) return stateAggregator.aliases.resolveUsername(defaultUsernameOrAlias);
+  throw new SfError(messages.getMessage('missingUsername'), 'MissingUsernameError');
+};
+
+/**
+ * Almost like the use case for the normal optional org flag,
+ * but delete commands need to handle the situation where connecting to the org fails because it's expired.
+ *
+ * Returns the username so you can construct your own org.
+ */
+export const orgThatMightBeDeleted = Flags.custom({
+  char: 'o',
+  required: true,
+  deprecateAliases: true,
+  aliases: ['targetusername', 'u'],
+  parse: async (input: string | undefined) => resolveUsername(input),
+  default: async () => resolveUsername(),
+  defaultHelp: async () => resolveUsername(),
+});

--- a/test/nut/scratchDelete.nut.ts
+++ b/test/nut/scratchDelete.nut.ts
@@ -14,6 +14,7 @@ import { ScratchDeleteResponse } from '../../src/commands/org/delete/scratch';
 describe('env:delete:scratch NUTs', () => {
   const scratchOrgAlias = 'scratch-org';
   const scratchOrgAlias2 = 'scratch-org-2';
+  const scratchOrgAlias3 = 'scratch-org-3';
   let session: TestSession;
 
   before(async () => {
@@ -33,6 +34,7 @@ describe('env:delete:scratch NUTs', () => {
         },
         {
           setDefault: true,
+          alias: scratchOrgAlias3,
           duration: 1,
           config: path.join('config', 'project-scratch-def.json'),
         },

--- a/test/unit/force/org/delete.test.ts
+++ b/test/unit/force/org/delete.test.ts
@@ -4,13 +4,12 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ConfigAggregator, Messages, Org, SfError } from '@salesforce/core';
+import { Messages, Org, SfError } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
 
 import { config, expect } from 'chai';
 import { stubPrompter, stubSfCommandUx } from '@salesforce/sf-plugins-core';
 import { SandboxAccessor } from '@salesforce/core/lib/stateAggregator/accessors/sandboxAccessor';
-import { Config } from '@oclif/core';
 import { Delete } from '../../../../src/commands/force/org/delete';
 
 config.truncateThreshold = 0;
@@ -29,18 +28,14 @@ describe('org:delete', () => {
 
   beforeEach(async () => {
     await $$.stubAuths(testOrg, testHub);
-    await $$.stubConfig({ 'target-org': testOrg.username });
     prompterStubs = stubPrompter($$.SANDBOX);
     sfCommandUxStubs = stubSfCommandUx($$.SANDBOX);
   });
 
   it('will throw an error when no default set', async () => {
-    const deleteCommand = new Delete([], {} as Config);
-    deleteCommand.configAggregator = await ConfigAggregator.create();
-    $$.SANDBOX.stub(deleteCommand.configAggregator, 'getPropertyValue').onSecondCall().returns(undefined);
-
+    await $$.stubConfig({});
     try {
-      await deleteCommand.run();
+      await Delete.run();
       expect.fail('should have thrown an error');
     } catch (e) {
       const err = e as SfError;
@@ -50,10 +45,8 @@ describe('org:delete', () => {
   });
 
   it('will prompt before attempting to delete', async () => {
-    const deleteCommand = new Delete([], {} as Config);
-    deleteCommand.configAggregator = await ConfigAggregator.create();
-    $$.SANDBOX.stub(deleteCommand.configAggregator, 'getPropertyValue').onThirdCall().returns(testOrg.username);
-    const res = await deleteCommand.run();
+    await $$.stubConfig({ 'target-org': testOrg.username });
+    const res = await Delete.run([]);
     expect(prompterStubs.confirm.calledOnce).to.equal(true);
     expect(prompterStubs.confirm.firstCall.args[0]).to.equal(
       messages.getMessage('confirmDelete', ['scratch', testOrg.username])
@@ -62,19 +55,13 @@ describe('org:delete', () => {
   });
 
   it('will resolve a default alias', async () => {
-    const deleteCommand = new Delete([], {} as Config);
-    deleteCommand.configAggregator = await ConfigAggregator.create();
     await $$.stubConfig({ 'target-org': 'myAlias' });
     $$.stubAliases({ myAlias: testOrg.username });
-    const getPropertyValueStub = $$.SANDBOX.stub(deleteCommand.configAggregator, 'getPropertyValue')
-      .onSecondCall()
-      .returns('myAlias');
-    const res = await deleteCommand.run();
+    const res = await Delete.run([]);
     expect(prompterStubs.confirm.calledOnce).to.equal(true);
     expect(prompterStubs.confirm.firstCall.args[0]).to.equal(
       messages.getMessage('confirmDelete', ['scratch', testOrg.username])
     );
-    expect(getPropertyValueStub.calledTwice).to.be.true;
     expect(res).to.deep.equal({ orgId: testOrg.orgId, username: testOrg.username });
   });
 

--- a/test/unit/org/list.test.ts
+++ b/test/unit/org/list.test.ts
@@ -4,8 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { expect, use as ChaiUse } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import { TestContext } from '@salesforce/core/lib/testSetup';
 import { AuthInfo, Connection, Org } from '@salesforce/core';
 import { stubMethod } from '@salesforce/ts-sinon';
@@ -13,8 +12,6 @@ import { SfCommand, stubSfCommandUx } from '@salesforce/sf-plugins-core';
 import OrgListMock = require('../../shared/orgListMock');
 import { OrgListCommand } from '../../../src/commands/org/list';
 import { OrgListUtil } from '../../../src/shared/orgListUtil';
-
-ChaiUse(chaiAsPromised);
 
 describe('org:list', () => {
   // Create new TestContext, which automatically creates and restores stubs


### PR DESCRIPTION
### What does this PR do?
can delete a default org when it's an alias

### What issues does this PR fix or reference?
[skip-validate-pr]