### PR TITLE
fix: small fixes to --help examples

### DIFF
--- a/messages/create_scratch.md
+++ b/messages/create_scratch.md
@@ -24,7 +24,7 @@ You must specify a Dev Hub to create a scratch org, either with the --target-dev
 
 - Create a Developer edition scratch org using your default Dev Hub and give the scratch org an alias:
 
-  <%= config.bin %> <%= command.id %> --edition=developer --alias my-scratch-org
+  <%= config.bin %> <%= command.id %> --edition developer --alias my-scratch-org
 
 - Create a scratch org with a definition file. Specify the Dev Hub using its alias, set the scratch org as your default, and specify that it expires in 3 days:
 
@@ -32,7 +32,7 @@ You must specify a Dev Hub to create a scratch org, either with the --target-dev
 
 - Create a preview Enterprise edition scratch org; for use only during Salesforce release transition periods:
 
-  <%= config.bin %> <%= command.id %> --edition=enterprise --alias my-scratch-org --target-dev-hub MyHub --release preview
+  <%= config.bin %> <%= command.id %> --edition enterprise --alias my-scratch-org --target-dev-hub MyHub --release preview
 
 # flags.target-hub.summary
 

--- a/messages/delete_sandbox.md
+++ b/messages/delete_sandbox.md
@@ -11,15 +11,15 @@ Specify a sandbox with either the username you used when you logged into it, or 
 
 - Delete a sandbox with alias my-sandbox:
 
-  <%= config.bin %> <%= command.id %> --target-org=my-sandbox
+  <%= config.bin %> <%= command.id %> --target-org my-sandbox
 
 - Specify a username instead of an alias:
 
-  <%= config.bin %> <%= command.id %> --target-org=myusername@example.com.qa
+  <%= config.bin %> <%= command.id %> --target-org myusername@example.com.qa
 
 - Delete the sandbox without prompting to confirm :
 
-  <%= config.bin %> <%= command.id %> --target-org=my-sandbox --no-prompt
+  <%= config.bin %> <%= command.id %> --target-org my-sandbox --no-prompt
 
 # flags.target-org.summary
 

--- a/messages/delete_scratch.md
+++ b/messages/delete_scratch.md
@@ -11,15 +11,15 @@ Specify a scratch org with either the username or the alias you gave the scratch
 
 - Delete a scratch org with alias my-scratch-org:
 
-  <%= config.bin %> <%= command.id %> --target-org=my-scratch-org
+  <%= config.bin %> <%= command.id %> --target-org my-scratch-org
 
 - Specify a username instead of an alias:
 
-  <%= config.bin %> <%= command.id %> --target-org=test-123456-abcdefg@example.com
+  <%= config.bin %> <%= command.id %> --target-org test-123456-abcdefg@example.com
 
 - Delete the scratch org without prompting to confirm :
 
-  <%= config.bin %> <%= command.id %> --target-org=my-scratch-org --no-prompt
+  <%= config.bin %> <%= command.id %> --target-org my-scratch-org --no-prompt
 
 # flags.target-org.summary
 


### PR DESCRIPTION
### What does this PR do?

Some examples still used "sfdx" style for flags (i.e. --edition=developer); changed it to sf style (--edition developer). 

### What issues does this PR fix or reference?

@W-13501919@