### PR TITLE
fix: remove logging that caused circular ref

### DIFF
--- a/src/commands/force/org/create.ts
+++ b/src/commands/force/org/create.ts
@@ -134,7 +134,6 @@ export class Create extends SfCommand<CreateResult> {
     this.flags = flags;
     this.varArgs = parseVarArgs(args, argv as string[]);
     this.logger = await Logger.child(this.constructor.name);
-    this.logger.debug('Create started with args %s ', flags);
 
     if (flags.type === OrgTypes.Sandbox) {
       this.validateSandboxFlags();


### PR DESCRIPTION
### What does this PR do?
Removes a log line that causes this error:
```
Error (1): Converting circular structure to JSON
    --> starting at object with constructor 'Timeout'
    |     property '_idlePrev' -> object with constructor 'TimersList'
    --- property '_idleNext' closes the circle
```

### What issues does this PR fix or reference?
@W-13123532@