### PR TITLE
fix: make help/errors more consistent when naming new commands

### DIFF
--- a/messages/create.md
+++ b/messages/create.md
@@ -4,7 +4,7 @@ Create a scratch org or sandbox.
 
 # deprecation
 
-The force:org:create command has been replaced. Try org:create:scratch or org:create:sandbox.
+The force:org:create command is deprecated. Try "org create scratch" or "org create sandbox" instead.
 
 # description
 

--- a/messages/delete.md
+++ b/messages/delete.md
@@ -4,12 +4,11 @@ Delete a scratch or sandbox org.
 
 # deprecation
 
-The force:org:delete command is deprecated. Use org:delete:scratch or org:delete:sandbox.
+The force:org:delete command is deprecated. Try "org delete scratch" or "org delete sandbox" instead.
 
 # description
 
-Salesforce CLI marks the org for deletion in either the Dev Hub org (for scratch orgs) or production org (for sandboxes)
-and then deletes all local references to the org from your computer.
+Salesforce CLI marks the org for deletion in either the Dev Hub org (for scratch orgs) or production org (for sandboxes) and then deletes all local references to the org from your computer.
 
 To mark the org for deletion without being prompted to confirm, specify --noprompt.
 

--- a/messages/display.md
+++ b/messages/display.md
@@ -8,7 +8,7 @@ Output includes your access token, client Id, connected status, org ID, instance
 
 Use --verbose to include the SFDX auth URL. WARNING: The SFDX auth URL contains sensitive information, such as a refresh token that can be used to access an org. Don't share or distribute this URL or token.
 
-Including --verbose displays the sfdxAuthUrl property only if you authenticated to the org using auth:web:login (not auth:jwt:grant).
+Including --verbose displays the sfdxAuthUrl property only if you authenticated to the org using "org login web" (not "org login jwt").
 
 # flags.verbose.summary
 

--- a/messages/list.md
+++ b/messages/list.md
@@ -26,7 +26,7 @@ Include expired, deleted, and unknown-status scratch orgs.
 
 # flags.clean.summary
 
-Remove all local org authorizations for non-active scratch orgs. Use auth:logout to remove non-scratch orgs.
+Remove all local org authorizations for non-active scratch orgs. Use "org logout" to remove non-scratch orgs.
 
 # flags.noPrompt.summary
 
@@ -46,7 +46,7 @@ No active scratch orgs found. Specify --all to see all scratch orgs.
 
 # deleteOrgs
 
-You have %s expired or deleted local scratch org authorizations. To remove authorizations for inactive orgs, run org:list --clean.
+You have %s expired or deleted local scratch org authorizations. To remove authorizations for inactive orgs, run "org list --clean".
 
 # noOrgsFound
 
@@ -54,7 +54,7 @@ No orgs can be found.
 
 # noOrgsFoundAction
 
-Use one of the auth commands or org:create:scratch to add or create a scratch org.
+Use one of the "org login" commands or "org create scratch" to add or create a scratch org.
 
 # noResultsFound
 
@@ -62,4 +62,4 @@ No non-scratch orgs found.
 
 # cleanWarning
 
-Unable to clean org with username %s. You can run "%s org:delete:scratch -o %s" to remove it.`
+Unable to clean org with username %s. You can run "%s org delete scratch -o %s" to remove it.`

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -2,4 +2,4 @@
 
 This command will expose sensitive information that allows for subsequent activity using your current authenticated session.
 Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege.
-For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm
+For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm.


### PR DESCRIPTION
### What does this PR do?

Cleans up help and error messages, trying to consistently name the new commands without colons, and more stuff. 

### What issues does this PR fix or reference?
@W-13555106@