### PR TITLE
Ensure sfdx dir exists

### DIFF
--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -129,6 +129,10 @@ export class OrgListUtil {
    * @param fileNames All the filenames in the global hidden folder
    */
   public static async readAuthFiles(fileNames: string[]): Promise<AuthInfo[]> {
+    // Ensure that the Global.SFDX_DIR exists
+    // https://github.com/forcedotcom/cli/issues/2222
+    await fs.mkdir(Global.SFDX_DIR, { recursive: true });
+
     const orgFileNames = (await fs.readdir(Global.SFDX_DIR)).filter((filename: string) =>
       filename.match(/^00D.{15}\.json$/g)
     );


### PR DESCRIPTION
### What does this PR do?
Prevents https://github.com/forcedotcom/cli/issues/2222 from happening again.
This was unintentionally fixed in https://github.com/forcedotcom/sfdx-core/pull/842

### What issues does this PR fix or reference?
[@W-13602928@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13602928)

QA
I reverted back to an older version of the CLI (1.194.1) and then I modified `plugin-org` directly with the same `mkdir` code
<img width="1075" alt="Screenshot 2023-06-15 at 3 11 21 PM" src="https://github.com/salesforcecli/plugin-org/assets/1715111/335bb52f-9c35-4342-8ce5-708cd923f797">

Confirm existing directory does not cause issues
<img width="934" alt="Screenshot 2023-06-15 at 3 22 06 PM" src="https://github.com/salesforcecli/plugin-org/assets/1715111/e67700b8-4d84-471d-8a03-e10af5e0f59e">

