### PR TITLE
Sm/sandboxes-in-list

### DIFF
--- a/messages/list.md
+++ b/messages/list.md
@@ -58,7 +58,7 @@ Use one of the "org login" commands or "org create scratch" to add or create a s
 
 # noResultsFound
 
-No %s found.
+No Orgs found.
 
 # cleanWarning
 

--- a/messages/list.md
+++ b/messages/list.md
@@ -58,7 +58,7 @@ Use one of the "org login" commands or "org create scratch" to add or create a s
 
 # noResultsFound
 
-No non-scratch orgs found.
+No %s found.
 
 # cleanWarning
 

--- a/schemas/org-list.json
+++ b/schemas/org-list.json
@@ -9,16 +9,35 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ExtendedAuthFields"
-          }
+          },
+          "deprecated": "preserved for backward json compatibility.  Duplicates devHubs, sandboxes, regularOrgs, which should be preferred"
         },
         "scratchOrgs": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/FullyPopulatedScratchOrgFields"
           }
+        },
+        "sandboxes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtendedAuthFields"
+          }
+        },
+        "regularOrgs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtendedAuthFields"
+          }
+        },
+        "devHubs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtendedAuthFields"
+          }
         }
       },
-      "required": ["nonScratchOrgs", "scratchOrgs"],
+      "required": ["nonScratchOrgs", "scratchOrgs", "sandboxes", "regularOrgs", "devHubs"],
       "additionalProperties": false
     },
     "ExtendedAuthFields": {

--- a/schemas/org-list.json
+++ b/schemas/org-list.json
@@ -24,7 +24,7 @@
             "$ref": "#/definitions/ExtendedAuthFields"
           }
         },
-        "regularOrgs": {
+        "other": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ExtendedAuthFields"
@@ -37,7 +37,7 @@
           }
         }
       },
-      "required": ["nonScratchOrgs", "scratchOrgs", "sandboxes", "regularOrgs", "devHubs"],
+      "required": ["nonScratchOrgs", "scratchOrgs", "sandboxes", "other", "devHubs"],
       "additionalProperties": false
     },
     "ExtendedAuthFields": {

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -26,7 +26,7 @@ export type OrgListResult = {
   nonScratchOrgs: ExtendedAuthFields[];
   scratchOrgs: FullyPopulatedScratchOrgFields[];
   sandboxes: ExtendedAuthFields[];
-  regularOrgs: ExtendedAuthFields[];
+  other: ExtendedAuthFields[];
   devHubs: ExtendedAuthFields[];
 };
 
@@ -68,7 +68,7 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
     const metaConfigs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
     const groupedSortedOrgs = {
       devHubs: metaConfigs.devHubs.map(decorateWithDefaultStatus).sort(comparator),
-      regularOrgs: metaConfigs.regularOrgs.map(decorateWithDefaultStatus).sort(comparator),
+      other: metaConfigs.other.map(decorateWithDefaultStatus).sort(comparator),
       sandboxes: metaConfigs.sandboxes.map(decorateWithDefaultStatus).sort(comparator),
       nonScratchOrgs: metaConfigs.nonScratchOrgs.map(decorateWithDefaultStatus).sort(comparator),
       scratchOrgs: metaConfigs.scratchOrgs.map(decorateWithDefaultStatus).sort(comparator),
@@ -84,7 +84,7 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
     }
 
     const result = {
-      regularOrgs: groupedSortedOrgs.regularOrgs,
+      other: groupedSortedOrgs.other,
       sandboxes: groupedSortedOrgs.sandboxes,
       nonScratchOrgs: groupedSortedOrgs.nonScratchOrgs,
       devHubs: groupedSortedOrgs.devHubs,
@@ -95,7 +95,7 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
 
     this.printOrgTable({
       devHubs: result.devHubs,
-      regularOrgs: result.regularOrgs,
+      other: result.other,
       sandboxes: result.sandboxes,
       scratchOrgs: result.scratchOrgs,
       skipconnectionstatus: flags['skip-connection-status'],
@@ -143,17 +143,17 @@ Legend:  ${defaultHubEmoji}=Default DevHub, ${defaultOrgEmoji}=Default Org ${
   protected printOrgTable({
     devHubs,
     scratchOrgs,
-    regularOrgs,
+    other,
     sandboxes,
     skipconnectionstatus,
   }: {
     devHubs: ExtendedAuthFields[];
-    regularOrgs: ExtendedAuthFields[];
+    other: ExtendedAuthFields[];
     sandboxes: ExtendedAuthFields[];
     scratchOrgs: FullyPopulatedScratchOrgFields[];
     skipconnectionstatus: boolean;
   }): void {
-    if (!devHubs.length && !regularOrgs.length && !sandboxes.length) {
+    if (!devHubs.length && !other.length && !sandboxes.length) {
       this.info(messages.getMessage('noResultsFound'));
       return;
     }
@@ -164,7 +164,7 @@ Legend:  ${defaultHubEmoji}=Default DevHub, ${defaultOrgEmoji}=Default Org ${
         .map((row) => getStyledObject(row))
         .map(statusToEmoji),
 
-      ...regularOrgs
+      ...other
         .map(colorEveryFieldButConnectedStatus(chalk.magentaBright))
         .map((row) => getStyledObject(row))
         .map(statusToEmoji),

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -100,7 +100,6 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
       scratchOrgs: result.scratchOrgs,
       skipconnectionstatus: flags['skip-connection-status'],
     });
-    // this.printScratchOrgTable(result.scratchOrgs);
 
     this.log(
       `
@@ -226,11 +225,12 @@ const statusToEmoji = <T extends ExtendedAuthFields | FullyPopulatedScratchOrgFi
   defaultMarker: val.defaultMarker?.replace('(D)', defaultHubEmoji)?.replace('(U)', defaultOrgEmoji),
 });
 
+const EMPTIES_LAST = 'zzzzzzzzzz';
+
 // sort by alias then username
 const comparator = <T extends ExtendedAuthFields | FullyPopulatedScratchOrgFields>(a: T, b: T): number => {
-  const emptiesLast = Array(10).fill('z').join('');
-  const aliasCompareResult = (a.alias ?? emptiesLast).localeCompare(b.alias ?? emptiesLast);
-  return aliasCompareResult !== 0 ? aliasCompareResult : (a.username ?? emptiesLast).localeCompare(b.username);
+  const aliasCompareResult = (a.alias ?? EMPTIES_LAST).localeCompare(b.alias ?? EMPTIES_LAST);
+  return aliasCompareResult !== 0 ? aliasCompareResult : (a.username ?? EMPTIES_LAST).localeCompare(b.username);
 };
 
 const getAuthFileNames = async (): Promise<string[]> => {

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -101,10 +101,10 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
       skipconnectionstatus: flags['skip-connection-status'],
     });
 
-    this.log(
+    this.info(
       `
 Legend:  ${defaultHubEmoji}=Default DevHub, ${defaultOrgEmoji}=Default Org ${
-        this.flags.all ? '   Use --all to see expired and deleted scratch orgs' : ''
+        flags.all ? '' : '     Use --all to see expired and deleted scratch orgs'
       }`
     );
 

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -16,8 +16,8 @@ import { ExtendedAuthFields, FullyPopulatedScratchOrgFields } from '../../shared
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'list');
 
-const defaultOrgEmoji = '🍁';
-const defaultHubEmoji = '🌳';
+export const defaultOrgEmoji = '🍁';
+export const defaultHubEmoji = '🌳';
 
 export type OrgListResult = {
   /**

--- a/src/shared/orgHighlighter.ts
+++ b/src/shared/orgHighlighter.ts
@@ -19,6 +19,7 @@ const styledProperties = new Map<string, Map<string, chalk.Chalk>>([
     'connectedStatus',
     new Map([
       ['Connected', chalk.green],
+      ['Active', chalk.green],
       ['else', chalk.red],
     ]),
   ],
@@ -34,11 +35,10 @@ export const getStyledValue = (key: string, value: string): string => {
   return chalkMethod(value);
 };
 
-export const getStyledObject = (
-  objectToStyle: ExtendedAuthFields | FullyPopulatedScratchOrgFields | Record<string, string>
-): Record<string, string> => {
-  const clonedObject = { ...objectToStyle };
-  return Object.fromEntries(
-    Object.entries(clonedObject).map(([key, value]) => [key, getStyledValue(key, value as string)])
-  );
-};
+export const getStyledObject = <T extends ExtendedAuthFields | FullyPopulatedScratchOrgFields>(objectToStyle: T): T =>
+  Object.fromEntries(
+    Object.entries(objectToStyle).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? getStyledValue(key, value) : value,
+    ])
+  ) as T;

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -38,6 +38,9 @@ type OrgGroups = {
 type OrgGroupsFullyPopulated = {
   nonScratchOrgs: ExtendedAuthFields[];
   scratchOrgs: FullyPopulatedScratchOrgFields[];
+  regularOrgs: ExtendedAuthFields[];
+  sandboxes: ExtendedAuthFields[];
+  devHubs: ExtendedAuthFields[];
 };
 
 type ExtendedScratchOrgInfo = Record &
@@ -93,6 +96,9 @@ export class OrgListUtil {
     return {
       nonScratchOrgs,
       scratchOrgs,
+      sandboxes: nonScratchOrgs.filter(sandboxFilter),
+      regularOrgs: nonScratchOrgs.filter(regularOrgFilter),
+      devHubs: nonScratchOrgs.filter(devHubFilter),
     };
   }
 
@@ -367,3 +373,7 @@ const removeRestrictedInfoFromConfig = (
   config: AuthFieldsFromFS,
   properties: string[] = ['refreshToken', 'clientSecret']
 ): AuthFieldsFromFS => omit<Omit<AuthFieldsFromFS, 'refreshToken' | 'clientSecret'>>(config, properties);
+
+const sandboxFilter = (org: AuthFieldsFromFS): boolean => Boolean(org.isSandbox);
+const regularOrgFilter = (org: AuthFieldsFromFS): boolean => !org.isSandbox && !org.isDevHub;
+const devHubFilter = (org: AuthFieldsFromFS): boolean => Boolean(org.isDevHub);

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -38,7 +38,7 @@ type OrgGroups = {
 type OrgGroupsFullyPopulated = {
   nonScratchOrgs: ExtendedAuthFields[];
   scratchOrgs: FullyPopulatedScratchOrgFields[];
-  regularOrgs: ExtendedAuthFields[];
+  other: ExtendedAuthFields[];
   sandboxes: ExtendedAuthFields[];
   devHubs: ExtendedAuthFields[];
 };
@@ -97,7 +97,7 @@ export class OrgListUtil {
       nonScratchOrgs,
       scratchOrgs,
       sandboxes: nonScratchOrgs.filter(sandboxFilter),
-      regularOrgs: nonScratchOrgs.filter(regularOrgFilter),
+      other: nonScratchOrgs.filter(regularOrgFilter),
       devHubs: nonScratchOrgs.filter(devHubFilter),
     };
   }

--- a/test/nut/listAndDisplay.nut.ts
+++ b/test/nut/listAndDisplay.nut.ts
@@ -11,7 +11,7 @@ import { expect, config, assert } from 'chai';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
 import { getString } from '@salesforce/ts-types';
-import { OrgListResult } from '../../src/commands/org/list';
+import { OrgListResult, defaultHubEmoji, defaultOrgEmoji } from '../../src/commands/org/list';
 import { OrgOpenOutput } from '../../src/commands/org/open';
 import { OrgDisplayReturn } from '../../src/shared/orgTypes';
 
@@ -27,11 +27,11 @@ const verifyHumanResults = (
   expect(lines.length).to.have.greaterThan(0);
   const devHubLine = lines.find((line) => line.includes(hubOrgUsername));
   assert(devHubLine);
-  expect(devHubLine).to.include('(D)');
+  expect(devHubLine).to.include(defaultHubEmoji);
   expect(devHubLine).to.include('Connected');
   const defaultUserLine = lines.find((line) => line.includes(defaultUsername));
   assert(defaultUserLine);
-  expect(defaultUserLine).to.include('(U)');
+  expect(defaultUserLine).to.include(defaultOrgEmoji);
   const aliasUserLine = lines.find((line) => line.includes(aliasedUsername));
   assert(aliasUserLine);
   expect(aliasUserLine).to.include('anAlias');
@@ -100,8 +100,8 @@ describe('Org Command NUT', () => {
       expect(listResult.scratchOrgs).to.have.length(2);
       const scratchOrgs = listResult.scratchOrgs;
       expect(scratchOrgs.map((scratchOrg) => getString(scratchOrg, 'username'))).to.deep.equal([
-        defaultUsername,
         aliasedUsername,
+        defaultUsername,
       ]);
       expect(scratchOrgs.find((org) => org.username === defaultUsername)).to.include({
         defaultMarker: '(U)',
@@ -113,6 +113,15 @@ describe('Org Command NUT', () => {
         namespace: null,
       });
       expect(listResult.nonScratchOrgs[0]).to.include(
+        {
+          username: hubOrgUsername,
+          defaultMarker: '(D)',
+          isDevHub: true,
+          connectedStatus: 'Connected',
+        },
+        JSON.stringify(listResult.nonScratchOrgs[0])
+      );
+      expect(listResult.devHubs[0]).to.include(
         {
           username: hubOrgUsername,
           defaultMarker: '(D)',

--- a/test/shared/orgHighlighter.test.ts
+++ b/test/shared/orgHighlighter.test.ts
@@ -6,6 +6,7 @@
  */
 import { expect } from 'chai';
 import * as chalk from 'chalk';
+import { ExtendedAuthFields } from '../../src/shared/orgTypes';
 import { getStyledObject, getStyledValue } from '../../src/shared/orgHighlighter';
 
 describe('highlights value from key-value pair', () => {
@@ -26,7 +27,8 @@ describe('highlights object with green, red, and non-colored', () => {
       status: 'Active',
       otherProp: 'foo',
       connectedStatus: 'Not found',
-    };
+      // I know it's not, but it's a test
+    } as unknown as ExtendedAuthFields;
     expect(getStyledObject(object)).to.deep.equal({
       status: chalk.green('Active'),
       otherProp: 'foo',

--- a/test/shared/orgListMock.ts
+++ b/test/shared/orgListMock.ts
@@ -104,7 +104,7 @@ class OrgListMock {
       },
     ],
     sandboxes: [],
-    regularOrgs: [],
+    other: [],
   };
 
   public static get devHubUsername(): string {

--- a/test/shared/orgListMock.ts
+++ b/test/shared/orgListMock.ts
@@ -96,6 +96,15 @@ class OrgListMock {
         connectedStatus: 'Connected',
       },
     ],
+    devHubs: [
+      {
+        username: 'foo@example.com',
+        isDevHub: true,
+        connectedStatus: 'Connected',
+      },
+    ],
+    sandboxes: [],
+    regularOrgs: [],
   };
 
   public static get devHubUsername(): string {


### PR DESCRIPTION
### What does this PR do?

well, this started off as "make sandboxes a section within org:list" (we can do that more reliably now thanks to Steve's PR for identifying them)

also, while I was in here, I realized **how ugly that table is**.  So

1. remove all the extra ASCII characters.
2. default markers (U) and (D) don't mean anything and don't even align with flags anymore.  Those are now emojis and there's a legend at the bottom of the table.  If you've got better emojideas, holler.
3. One table so the columns align
4. Type field (DevHub, Sandbox, Scratch Org, ?) [the original WI]
5. colors by type, orgs are grouped by those types
6. aliases are at the top of their section instead of the bottom
7. instanceUrl appears when `--verbose` for non-scratch orgs, too
8. long datestamp for createdDate is now just yyyy-mm-dd to match ExpirationDate
9. Column headers are title case instead of UPPERCASE

No JSON should be harmed in the making of this PR

### What issues does this PR fix or reference?
@W-10983482@