### PR TITLE
fix: skip-connection-status flag works

### DIFF
--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -65,7 +65,10 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
   public async run(): Promise<OrgListResult> {
     const [{ flags }, fileNames] = await Promise.all([this.parse(OrgListCommand), getAuthFileNames()]);
     this.flags = flags;
-    const metaConfigs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+    const metaConfigs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(
+      fileNames,
+      flags['skip-connection-status']
+    );
     const groupedSortedOrgs = {
       devHubs: metaConfigs.devHubs.map(decorateWithDefaultStatus).sort(comparator),
       other: metaConfigs.other.map(decorateWithDefaultStatus).sort(comparator),

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -18,7 +18,7 @@ import {
   ConfigAggregator,
   OrgConfigProperties,
 } from '@salesforce/core';
-import { Dictionary, isObject } from '@salesforce/ts-types';
+import { isObject } from '@salesforce/ts-types';
 import { Record } from 'jsforce';
 import { omit } from '@salesforce/kit/lib';
 import { getAliasByUsername } from './utils';
@@ -69,7 +69,7 @@ export class OrgListUtil {
    */
   public static async readLocallyValidatedMetaConfigsGroupedByOrgType(
     userFilenames: string[],
-    flags: Dictionary<string | boolean>
+    skipConnection = false
   ): Promise<OrgGroupsFullyPopulated> {
     const contents: AuthInfo[] = await OrgListUtil.readAuthFiles(userFilenames);
     const orgs = await OrgListUtil.groupOrgs(contents);
@@ -78,7 +78,7 @@ export class OrgListUtil {
     const [nonScratchOrgs, scratchOrgs] = await Promise.all([
       Promise.all(
         orgs.nonScratchOrgs.map(async (fields) => {
-          if (!flags.skipconnectionstatus && fields.username) {
+          if (!skipConnection && fields.username) {
             // skip completely if we're skipping the connection
             fields.connectedStatus = await OrgListUtil.determineConnectedStatusForNonScratchOrg(fields.username);
             if (!fields.isDevHub && fields.connectedStatus === 'Connected') {

--- a/test/shared/orgListUtil.test.ts
+++ b/test/shared/orgListUtil.test.ts
@@ -153,6 +153,15 @@ describe('orgListUtil tests', () => {
       expect(determineConnectedStatusForNonScratchOrg.called).to.be.false;
     });
 
+    it('skipconnectionstatus with default', async () => {
+      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames);
+      expect(orgs.nonScratchOrgs.every((org) => org.connectedStatus !== undefined)).to.be.true;
+      expect(orgs.other.every((org) => org.connectedStatus !== undefined)).to.be.true;
+      expect(orgs.sandboxes.every((org) => org.connectedStatus !== undefined)).to.be.true;
+
+      expect(determineConnectedStatusForNonScratchOrg.called).to.be.true;
+    });
+
     it('should omit sensitive information and catergorise active and non-active scracth orgs', async () => {
       const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, false);
 

--- a/test/shared/orgListUtil.test.ts
+++ b/test/shared/orgListUtil.test.ts
@@ -128,8 +128,7 @@ describe('orgListUtil tests', () => {
     });
 
     it('readLocallyValidatedMetaConfigsGroupedByOrgType', async () => {
-      const flags = {};
-      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, false);
       expect(orgs.nonScratchOrgs.every((nonScratchOrg) => nonScratchOrg.connectedStatus !== undefined)).to.be.true;
       expect(orgs.scratchOrgs.length).to.equal(2);
       expect(orgs.scratchOrgs[0]).to.haveOwnProperty('username').to.equal('gaz@foo.org');
@@ -143,8 +142,7 @@ describe('orgListUtil tests', () => {
     });
 
     it('skipconnectionstatus', async () => {
-      const flags = { skipconnectionstatus: true };
-      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, true);
 
       // we didn't check the status, so the hub is still not known to be a devhub
       expect(orgs.nonScratchOrgs[0].isDevHub).to.be.false;
@@ -156,8 +154,7 @@ describe('orgListUtil tests', () => {
     });
 
     it('should omit sensitive information and catergorise active and non-active scracth orgs', async () => {
-      const flags = {};
-      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+      const orgs = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, false);
 
       expect(orgs.scratchOrgs[0]).to.not.haveOwnProperty('clientSecret');
       expect(orgs.scratchOrgs[1]).to.not.haveOwnProperty('clientSecret');
@@ -166,15 +163,13 @@ describe('orgListUtil tests', () => {
     });
 
     it('should execute queries to check for org information if --verbose is used', async () => {
-      const flags = { verbose: true };
-      await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+      await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, true);
       expect(retrieveScratchOrgInfoFromDevHubStub.calledOnce).to.be.true;
       expect(spies.get('reduceScratchOrgInfo').calledOnce).to.be.true;
     });
 
     it('execute queries should add information to grouped orgs', async () => {
-      const flags = { verbose: true };
-      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, flags);
+      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, true);
       expect(retrieveScratchOrgInfoFromDevHubStub.calledOnce).to.be.true;
       expect(spies.get('reduceScratchOrgInfo').calledOnce).to.be.true;
       expect(orgGroups.scratchOrgs[0].signupUsername).to.equal(orgAuthConfigFields.username);
@@ -198,7 +193,7 @@ describe('orgListUtil tests', () => {
       stubMethod(sandbox, Org.prototype, 'getUsername').returns(devHubConfigFields.username);
       stubMethod(sandbox, Org.prototype, 'refreshAuth').rejects({ message: 'bad auth' });
 
-      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, {});
+      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, false);
       expect(orgGroups.nonScratchOrgs).to.have.length(1);
       expect(orgGroups.nonScratchOrgs[0].connectedStatus).to.equal('bad auth');
       expect(checkNonScratchOrgIsDevHub.called).to.be.false;
@@ -208,7 +203,7 @@ describe('orgListUtil tests', () => {
       determineConnectedStatusForNonScratchOrg.restore();
       stubMethod(sandbox, Org, 'create').rejects({ message: 'bad file' });
 
-      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, {});
+      const orgGroups = await OrgListUtil.readLocallyValidatedMetaConfigsGroupedByOrgType(fileNames, false);
       expect(orgGroups.nonScratchOrgs).to.have.length(1);
       expect(orgGroups.nonScratchOrgs[0].connectedStatus).to.equal('bad file');
       expect(checkNonScratchOrgIsDevHub.called).to.be.false;


### PR DESCRIPTION
### What does this PR do?
we've been ignoring `--skip-connection-status` since this command was sf-ified.  Flags weren't typed before.

### What issues does this PR fix or reference?
[@W-13957953@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001YYxGYYA1/view)
