### PR TITLE
fix(org status): improve err handling

### DIFF
--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -378,6 +378,6 @@ const authErrorHandler = async (err: unknown, username: string): Promise<string>
   // Orgs under maintenace return html as the error message.
   if (error.message.includes('maintenance')) return 'Down (Maintenance)';
   // handle other potential html responses
-  if (error.message.includes('<html>')) return 'Bad Response';
+  if (error.message.includes('<html>') || error.message.includes('<!DOCTYPE HTML>')) return 'Bad Response';
   return (error.code ?? error.message) as string;
 };


### PR DESCRIPTION
### What does this PR do?
Improves error handler when trying to get status of an org. 
before:
`org list` would check for `<html>` in err message
after:
`org list` will check for `html` **or** `<!DOCTYPE HTML>` to ensure it got an HTML response from the server.

Repro:
modify the instance url (make it point to an invalid url) of a non-hub org in its auth file, then run `sf org list`

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2533
@W-14348441@