### PR TITLE
Sm/missing-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ open source, it may not represent all of the `org` commands.
 
 ## About Salesforce CLI plugins
 
-Salesforce CLI plugins are based on the [oclif plugin framework](<(https://oclif.io/docs/introduction.html)>). Read
+Salesforce CLI plugins are based on the [oclif plugin framework](https://oclif.io/docs/introduction). Read
 the [plugin developer guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_plugins.meta/sfdx_cli_plugins/cli_plugins_architecture_sf_cli.htm)
 to learn about Salesforce CLI plugin development.
 
@@ -934,7 +934,7 @@ GLOBAL FLAGS
 DESCRIPTION
   Open your default scratch org, or another specified org, in a browser.
 
-  To open a specific page, specify the portion of the URL after "https://MyDomainName.my.salesforce.com/" as the value
+  To open a specific page, specify the portion of the URL after "https://MyDomainName.my.salesforce.com" as the value
   for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path
   /apex/YourPage" to open a Visualforce page.
 

--- a/messages/open.md
+++ b/messages/open.md
@@ -4,7 +4,7 @@ Open your default scratch org, or another specified org, in a browser.
 
 # description
 
-To open a specific page, specify the portion of the URL after "https://MyDomainName.my.salesforce.com/" as the value for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
+To open a specific page, specify the portion of the URL after "https://mydomain.my.salesforce.com" as the value for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
 
 Use the --source-file to open a Lightning Page from your local project in Lightning App Builder. Lightning page files have the suffix .flexipage-meta.xml, and are stored in the "flexipages" directory.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@salesforce/kit": "^3.0.15",
     "@salesforce/sf-plugins-core": "^5.0.3",
     "@salesforce/source-deploy-retrieve": "^10.0.3",
+    "chalk": "^4",
+    "change-case": "^5.3.0",
     "open": "^9.1.0"
   },
   "devDependencies": {

--- a/schemas/org-list.json
+++ b/schemas/org-list.json
@@ -58,7 +58,8 @@
           "enum": ["(D)", "(U)"]
         },
         "attributes": {
-          "$ref": "#/definitions/Dictionary%3Cunknown%3E"
+          "type": "object",
+          "additionalProperties": {}
         },
         "lastUsed": {
           "type": "string",
@@ -163,22 +164,6 @@
       },
       "required": ["accessToken", "clientId", "instanceUrl", "orgId", "string", "username"]
     },
-    "Dictionary<unknown>": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/Optional%3Cunknown%3E"
-      },
-      "description": "An object with arbitrary string-indexed values of an optional generic type `Optional<T>`. `T` defaults to `unknown` when not explicitly supplied. For convenient iteration of definitely assigned (i.e. non-nullable) entries, keys, and values, see the following functions:  {@link  definiteEntriesOf  } ,  {@link  definiteKeysOf  } , and  {@link  definiteValuesOf  } ."
-    },
-    "Optional<unknown>": {
-      "anyOf": [
-        {},
-        {
-          "not": {}
-        }
-      ],
-      "description": "A union type for either the parameterized type `T` or `undefined` -- the opposite of  {@link  NonOptional  } ."
-    },
     "FullyPopulatedScratchOrgFields": {
       "type": "object",
       "additionalProperties": false,
@@ -209,7 +194,8 @@
           "enum": ["(D)", "(U)"]
         },
         "attributes": {
-          "$ref": "#/definitions/Dictionary%3Cunknown%3E"
+          "type": "object",
+          "additionalProperties": {}
         },
         "lastUsed": {
           "type": "string",

--- a/src/commands/org/list/metadata-types.ts
+++ b/src/commands/org/list/metadata-types.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Messages } from '@salesforce/core';
-import { DescribeMetadataResult } from 'jsforce/api/metadata';
+import type { DescribeMetadataResult } from 'jsforce/api/metadata';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import { Flags, loglevel, requiredOrgFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 

--- a/src/commands/org/list/metadata.ts
+++ b/src/commands/org/list/metadata.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Messages } from '@salesforce/core';
-import { FileProperties, ListMetadataQuery } from 'jsforce/api/metadata';
+import type { FileProperties, ListMetadataQuery } from 'jsforce/api/metadata';
 import { Flags, loglevel, requiredOrgFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 
 Messages.importMessagesDirectory(dirname(fileURLToPath(import.meta.url)));

--- a/src/shared/orgHooks.ts
+++ b/src/shared/orgHooks.ts
@@ -5,13 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Optional } from '@salesforce/ts-types';
-import { AuthFields } from '@salesforce/core';
+import type { AuthFields } from '@salesforce/core';
 import { Command, Interfaces, Hook } from '@oclif/core';
 
 type HookOpts<T> = {
   options: { Command: Command.Class; argv: string[]; commandId: string };
-  return: Optional<T>;
+  return: T | undefined;
 };
 
 export type OrgCreateResult = Pick<

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -18,11 +18,10 @@ import {
   ConfigAggregator,
   OrgConfigProperties,
 } from '@salesforce/core';
-import { isObject } from '@salesforce/ts-types';
-import { Record } from 'jsforce';
+import type { Record } from 'jsforce';
 import { omit } from '@salesforce/kit';
-import utils from './utils.js';
-import {
+import utils, { isDefined } from './utils.js';
+import type {
   ScratchOrgInfoSObject,
   ExtendedAuthFields,
   ExtendedAuthFieldsScratch,
@@ -180,7 +179,7 @@ export class OrgListUtil {
         }
       })
     );
-    return allAuths.filter(isObject<AuthInfo>);
+    return allAuths.filter(isDefined);
   }
 
   /**
@@ -285,13 +284,13 @@ export class OrgListUtil {
         : `Can't find ${scratchOrgInfo.username} in the updated contents`;
     });
 
-    const warnings = results.filter((result) => typeof result === 'string') as string[];
+    const warnings = results.filter((result): result is string => typeof result === 'string');
     if (warnings.length) {
       const logger = await OrgListUtil.retrieveLogger();
       warnings.forEach((warning) => logger.warn(warning));
     }
 
-    return results.filter((result) => typeof result !== 'string') as FullyPopulatedScratchOrgFields[];
+    return results.filter((result): result is FullyPopulatedScratchOrgFields => typeof result !== 'string');
   }
 
   /**

--- a/src/shared/orgTypes.ts
+++ b/src/shared/orgTypes.ts
@@ -6,7 +6,6 @@
  */
 
 import { AuthFields, ScratchOrgInfo } from '@salesforce/core';
-import { Dictionary } from '@salesforce/ts-types';
 
 export type OrgDisplayReturn = Partial<ScratchOrgFields> & {
   username: string;
@@ -86,7 +85,7 @@ export interface OrgListFields {
   isDefaultUsername?: boolean;
   isDefaultDevHubUsername?: boolean;
   defaultMarker?: '(D)' | '(U)';
-  attributes?: Dictionary<unknown>;
+  attributes?: Record<string, unknown>;
   lastUsed?: Date;
 }
 

--- a/src/shared/sandboxProgress.ts
+++ b/src/shared/sandboxProgress.ts
@@ -10,6 +10,7 @@ import { Ux } from '@salesforce/sf-plugins-core/lib/ux';
 import { ux } from '@oclif/core';
 import { getClockForSeconds } from '../shared/timeUtils.js';
 import { StagedProgress } from './stagedProgress.js';
+import { isDefined } from './utils.js';
 
 const columns: Ux.Table.Columns<{ key: string; value: string }> = {
   key: { header: 'Field' },
@@ -74,7 +75,7 @@ export class SandboxProgress extends StagedProgress<SandboxStatusData> {
       'Sandbox Create Stages',
       this.formatStages(),
     ]
-      .filter((line) => line)
+      .filter(isDefined)
       .join(os.EOL);
   }
   // eslint-disable-next-line class-methods-use-this

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -28,3 +28,5 @@ export default {
   openUrl,
   lowerToUpper,
 };
+
+export const isDefined = <T>(value: T | undefined | null): value is T => value !== undefined && value !== null;

--- a/test/nut/async-create-resume.nut.ts
+++ b/test/nut/async-create-resume.nut.ts
@@ -10,7 +10,6 @@ import path from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { assert, expect } from 'chai';
 import { AuthFields, Global, ScratchOrgCache } from '@salesforce/core';
-import { JsonMap } from '@salesforce/ts-types';
 import { CachedOptions } from '@salesforce/core/lib/org/scratchOrgCache.js';
 import { Duration, sleep } from '@salesforce/kit';
 import { ScratchCreateResponse } from '../../src/shared/orgTypes.js';
@@ -120,7 +119,7 @@ describe('env:create:scratch async/resume', () => {
       expect(cache[soiId].definitionjson).to.deep.equal(
         JSON.parse(
           await fs.promises.readFile(path.join(session.project.dir, 'config', 'project-scratch-def.json'), 'utf8')
-        ) as unknown as JsonMap
+        )
       );
     });
     it('resumes org using latest', async () => {

--- a/test/nut/listAndDisplay.nut.ts
+++ b/test/nut/listAndDisplay.nut.ts
@@ -10,7 +10,6 @@ import os from 'node:os';
 import { expect, config, assert } from 'chai';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
-import { getString } from '@salesforce/ts-types';
 import { OrgListResult, defaultHubEmoji, defaultOrgEmoji } from '../../src/commands/org/list.js';
 import { OrgOpenOutput } from '../../src/commands/org/open.js';
 import { OrgDisplayReturn } from '../../src/shared/orgTypes.js';
@@ -99,10 +98,7 @@ describe('Org Command NUT', () => {
       expect(listResult).to.have.property('scratchOrgs');
       expect(listResult.scratchOrgs).to.have.length(2);
       const scratchOrgs = listResult.scratchOrgs;
-      expect(scratchOrgs.map((scratchOrg) => getString(scratchOrg, 'username'))).to.deep.equal([
-        aliasedUsername,
-        defaultUsername,
-      ]);
+      expect(scratchOrgs.map((scratchOrg) => scratchOrg.username)).to.deep.equal([aliasedUsername, defaultUsername]);
       expect(scratchOrgs.find((org) => org.username === defaultUsername)).to.include({
         defaultMarker: '(U)',
         isDefaultUsername: true,

--- a/test/nut/metadata.nut.ts
+++ b/test/nut/metadata.nut.ts
@@ -8,8 +8,8 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { DescribeMetadataResult } from 'jsforce/lib/api/metadata/schema.js';
-import { ListMetadataCommandResult } from '../../src/commands/org/list/metadata.js';
+import type { DescribeMetadataResult } from 'jsforce/lib/api/metadata/schema.js';
+import type { ListMetadataCommandResult } from '../../src/commands/org/list/metadata.js';
 
 describe('org list metadata*', () => {
   let session: TestSession;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,6 +2326,11 @@ change-case@^4, change-case@^4.1.2:
     snake-case "^3.0.4"
     tslib "^2.0.3"
 
+change-case@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.3.0.tgz#b2fc5a8bea0cf8b4856a5a9aaf79abd8ea5309f6"
+  integrity sha512-Eykca0fGS/xYlx2fG5NqnGSnsWauhSGiSXYhB1kO6E909GUfo8S54u4UZNS7lMJmgZumZ2SUpWaoLgAcfQRICg==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
### What does this PR do?
adds missing dependencies
note: chalk has a higher ESM major version than 4, but we can't use it becuase there's exported bits of chalk (standardColors) from sf-plugins-core and they're not compatible (api changes).

We'll need to use ESM chalk in sf-plugins-core and then could bump here and elsewhere

### What issues does this PR fix or reference?
https://github.com/forcedotcom/eslint-config-salesforce-typescript/actions/runs/7214346950/job/19656237273
