### PR TITLE
feat: hide deprecated commands

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Salesforce.com, Inc.
+Copyright (c) 2024, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/commands/force/org/clone.ts
+++ b/src/commands/force/org/clone.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import {
   Flags,
   SfCommand,
@@ -31,7 +29,7 @@ import {
 import requestFunctions from '../../../shared/sandboxRequest.js';
 import { SandboxReporter } from '../../../shared/sandboxReporter.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'clone');
 
 export class OrgCloneCommand extends SfCommand<SandboxProcessObject> {
@@ -40,6 +38,7 @@ export class OrgCloneCommand extends SfCommand<SandboxProcessObject> {
   public static readonly description = messages.getMessage('description');
   public static readonly strict = false;
   public static state = 'deprecated';
+  public static readonly hidden = true;
   public static deprecationOptions = {
     to: 'org:create:sandbox',
     version: '60.0',

--- a/src/commands/force/org/create.ts
+++ b/src/commands/force/org/create.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Interfaces } from '@oclif/core';
 import {
   Flags,
@@ -38,7 +36,7 @@ import {
 import requestFunctions from '../../../shared/sandboxRequest.js';
 import { SandboxReporter } from '../../../shared/sandboxReporter.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'create');
 
 export interface ScratchOrgProcessObject {
@@ -57,6 +55,7 @@ export class Create extends SfCommand<CreateResult> {
   public static readonly examples = messages.getMessages('examples');
 
   public static state = 'deprecated';
+  public static readonly hidden = true;
   public static deprecationOptions = {
     message: messages.getMessage('deprecation'),
   };

--- a/src/commands/force/org/delete.ts
+++ b/src/commands/force/org/delete.ts
@@ -5,12 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { AuthInfo, AuthRemover, Messages, Org, StateAggregator } from '@salesforce/core';
 import { orgThatMightBeDeleted } from '../../../shared/flags.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'delete');
 
 export type DeleteResult = {
@@ -23,6 +22,7 @@ export class Delete extends SfCommand<DeleteResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static state = 'deprecated';
+  public static readonly hidden = true;
   public static deprecationOptions = {
     message: messages.getMessage('deprecation'),
   };

--- a/src/commands/force/org/status.ts
+++ b/src/commands/force/org/status.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import {
   Flags,
   SfCommand,
@@ -28,7 +26,7 @@ import {
 } from '@salesforce/core';
 import { SandboxReporter } from '../../../shared/sandboxReporter.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'status');
 
 export class OrgStatusCommand extends SfCommand<SandboxProcessObject> {
@@ -36,6 +34,7 @@ export class OrgStatusCommand extends SfCommand<SandboxProcessObject> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static state = 'deprecated';
+  public static readonly hidden = true;
   public static deprecationOptions = {
     to: 'org:resume:sandbox',
     version: '60.0',


### PR DESCRIPTION
What does this PR do?
marks deprecated commands as hidden
[keep them out of docs, autocomplete, etc]

What issues does this PR fix or reference?
@W-14739853@