### PR TITLE
fix: properly parse edition flag

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Salesforce.com, Inc.
+Copyright (c) 2024, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/commands/org/create/scratch.ts
+++ b/src/commands/org/create/scratch.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import {
   Messages,
   Lifecycle,
@@ -21,7 +19,7 @@ import { Duration } from '@salesforce/kit';
 import { buildScratchOrgRequest } from '../../../shared/scratchOrgRequest.js';
 import { buildStatus } from '../../../shared/scratchOrgOutput.js';
 import { ScratchCreateResponse } from '../../../shared/orgTypes.js';
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'create_scratch');
 
 export const secretTimeout = 60000;
@@ -79,6 +77,15 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
         'partner-group',
         'partner-professional',
       ],
+      // eslint-disable-next-line @typescript-eslint/require-await
+      parse: async (value: string) => {
+        // the API expects partner editions in `partner <EDITION>` format.
+        // so we replace the hyphen here with a space.
+        if (value.startsWith('partner-')) {
+          return value.replace('-', ' ');
+        }
+        return value;
+      },
       helpGroup: definitionFileHelpGroupName,
     }),
     'no-namespace': Flags.boolean({


### PR DESCRIPTION
### What does this PR do?
Make `org create scratch --edition` handle `parter-*` values properly.

We are setting the `Edition` field for `ScratchOrgInfo` to `parter-<EDITION>` but the API expects these as `partner <EDITION>` (separated by space, no hyphen).

Keeping the `parter-<EDITION>` format allow us to still autocomplete these (can't insert values with spaces on zsh).

Repro:
1) try to create a scratch org with any of the allowed partner edition values:
```
➜  ~ sf org create scratch --edition partner-developer

Creating Scratch Org... Error
Error (1): Edition: bad value for restricted picklist field: partner-developer
```
2) link this branch of plugin-org into sf, then:
```
➜  ~ sf org create scratch --edition partner-developer
 ›   Warning: @salesforce/plugin-org is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.

Creating Scratch Org... Error
Error (1): You don't have permission to create Partner Edition organizations. To enable this functionality, please log a case in the Partner Community.
```

As Eric mentioned, our hub isn't configured for parter orgs but you can see the error returned by the API is correct.

https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_scratchorginfo.htm 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2614
@W-14700935@