### PR TITLE
fix: decode `path` flag before writing it to form

### DIFF
--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -130,7 +130,16 @@ export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
 
     // create a local html file that contains the POST stuff.
     const tempFilePath = path.join(tmpdir(), `org-open-${new Date().valueOf()}.html`);
-    await fs.promises.writeFile(tempFilePath, getFileContents(conn.accessToken as string, conn.instanceUrl, retUrl));
+    await fs.promises.writeFile(
+      tempFilePath,
+      getFileContents(
+        conn.accessToken as string,
+        conn.instanceUrl,
+        // the path flag is URI-encoded in its `parse` func.
+        // For the form redirect to work we need it decoded.
+        flags.path ? decodeURIComponent(flags.path) : retUrl
+      )
+    );
     const cp = await utils.openUrl(`file:///${tempFilePath}`, {
       ...(flags.browser ? { app: { name: apps[flags.browser] } } : {}),
       ...(flags.private ? { newInstance: platform() === 'darwin', app: { name: apps.browserPrivate } } : {}),


### PR DESCRIPTION
### What does this PR do?
Follow up from https://github.com/salesforcecli/plugin-org/pull/913

`sf org open --path <path>` isn't working on current nightly (sf v2.25.5).

<img width="1405" alt="Screenshot 2024-01-16 at 12 14 04" src="https://github.com/salesforcecli/plugin-org/assets/6853656/6deac960-949a-4743-839e-9d36d743613b">

`--path` is URI-encoded by default (for the old behavior of opening the url with the AT + path | source-file as param), but the form redirect requires is to be decoded:

<img width="1720" alt="Screenshot 2024-01-16 at 12 15 19" src="https://github.com/salesforcecli/plugin-org/assets/6853656/58454a7f-3bc1-4183-81b2-45c50deadf14">


tested on macos (firefox/chrome) and windows (firefox/edge)

### What issues does this PR fix or reference?
[skip-validate-pr]