### PR TITLE
fix: convert linux file path to Windows one in WSL

### DIFF
--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -8,6 +8,7 @@
 import path from 'node:path';
 import { platform, tmpdir } from 'node:os';
 import fs from 'node:fs';
+import { execSync } from 'node:child_process';
 import {
   Flags,
   loglevel,
@@ -140,7 +141,10 @@ export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
         flags.path ? decodeURIComponent(flags.path) : retUrl
       )
     );
-    const cp = await utils.openUrl(`file:///${tempFilePath}`, {
+    const filePathUrl = isWsl
+      ? 'file:///' + execSync(`wslpath -m ${tempFilePath}`).toString().trim()
+      : `file:///${tempFilePath}`;
+    const cp = await utils.openUrl(filePathUrl, {
       ...(flags.browser ? { app: { name: apps[flags.browser] } } : {}),
       ...(flags.private ? { newInstance: platform() === 'darwin', app: { name: apps.browserPrivate } } : {}),
     });


### PR DESCRIPTION
### What does this PR do?

Make `org open` command to convert Linux file path to Windows one in WSL.

`org open` command was changed to open temp html file from to open url directly.
In WSL, the command silently fails because Windows browser tries to open linux file path.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2677
[@W-15278875@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15278875)