### PR TITLE
doc: edit messages for new "org refresh sandbox" command

### DIFF
--- a/messages/create.sandbox.md
+++ b/messages/create.sandbox.md
@@ -6,15 +6,21 @@ Create a sandbox org.
 
 There are two ways to create a sandbox org: specify a definition file that contains the sandbox options or use the --name and --license-type flags to specify the two required options. If you want to set an option other than name or license type, such as apexClassId, you must use a definition file.
 
+You can also use this command to clone an existing sandbox. Use the --clone flag to specify the existing sandbox name and the --name flag to the name of the new sandbox.
+
 # examples
 
 - Create a sandbox org using a definition file and give it the alias "MyDevSandbox". The production org that contains the sandbox license has the alias "prodOrg".
 
-  <%= config.bin %> <%= command.id %> -f config/dev-sandbox-def.json --alias MyDevSandbox --target-org prodOrg
+  <%= config.bin %> <%= command.id %> --definition-file config/dev-sandbox-def.json --alias MyDevSandbox --target-org prodOrg
 
 - Create a sandbox org by directly specifying its name and type of license (Developer) instead of using a definition file. Set the sandbox org as your default.
 
   <%= config.bin %> <%= command.id %> --name mysandbox --license-type Developer --alias MyDevSandbox --target-org prodOrg --set-default
+
+- Clone the existing sandbox with name "ExistingSandbox" and name the new sandbox "NewClonedSandbox". Set the new sandbox as your default org. Wait for 30 minutes for the sandbox creation to complete.
+
+  <%= config.bin %> <%= command.id %> --clone ExistingSandbox --name NewClonedSandbox --target-org prodOrg --alias MyDevSandbox --set-default --wait 30
 
 # flags.setDefault.summary
 
@@ -58,7 +64,7 @@ Name of the sandbox org to clone.
 
 # flags.clone.description
 
-The value of clone must be an existing sandbox in the same target-org.
+The value of --clone must be an existing sandbox. The existing sandbox, and the new sandbox specified with the --name flag, must both be associated with the production org (--target-org) that contains the sandbox licenses.
 
 # flags.licenseType.summary
 

--- a/messages/refresh.sandbox.md
+++ b/messages/refresh.sandbox.md
@@ -1,58 +1,46 @@
 # summary
 
-Refresh (update) a sandbox org by the sandbox name.
+Refresh a sandbox org using the sandbox name.
 
 # description
 
-Refresh (update) a sandbox org by the sandbox name, using a definition file for any `SandboxInfo` overrides.
+Refreshing a sandbox copies the metadata, and optionally data, from your production org to the refreshed sandbox org. You can optionally specify a definition file if you want to change the configuration of the refreshed sandbox, such as its license type or template ID.
 
-Note that changing a sandbox name during a refresh is not allowed. If changing the sandbox name is desired, instead delete the sandbox and recreate it.
+You're not allowed to change the sandbox name when you refresh it with this command. If you want to change the sandbox name, first delete it with the "org delete sandbox" command. And then recreate it with the "org create sandbox" command and give it a new name.
 
 # examples
 
 - Refresh the sandbox named "devSbx1". The production org that contains the sandbox license has the alias "prodOrg".
 
-  <%= config.bin %> <%= command.id %> -n devSbx1 --target-org prodOrg
+  <%= config.bin %> <%= command.id %> --name devSbx1 --target-org prodOrg
 
-- Refresh the sandbox named "devSbx2", overriding the SandboxInfo used when created with the properties in a definition file. The default target org is the production org, so specifying the `--target-org` flag is not necessary in this case.
+- Refresh the sandbox named "devSbx2", and override the configuration of the refreshed sandbox with the properties in the specified defintion file. The default target org is the production org, so you don't need to specify the `--target-org` flag in this case.
 
-  <%= config.bin %> <%= command.id %> -n devSbx2 -f devSbx2-config.json
+  <%= config.bin %> <%= command.id %> --name devSbx2 --definition-file devSbx2-config.json
 
 - Refresh the sandbox using the name defined in the definition file. The production org that contains the sandbox license has the alias "prodOrg".
 
-  <%= config.bin %> <%= command.id %> --definition-file devSbx3-config.json -o prodOrg
+  <%= config.bin %> <%= command.id %> --definition-file devSbx3-config.json --target-org prodOrg
 
 # flags.auto-activate.summary
 
-[default: true] Activates the sandbox after successful refresh.
-
-# flags.auto-activate.description
-
-[default: true] Activates the sandbox after successful refresh.
+Activates the sandbox after a successful refresh.
 
 # flags.targetOrg.summary
 
 Username or alias of the production org that contains the sandbox license.
 
-# flags.targetOrg.description
-
-When it refreshes the sandbox org, Salesforce copies the metadata, and optionally data, from your production org to the sandbox org.
-
 # flags.definitionFile.summary
 
-Path to a sandbox definition file used to override the configuration used when created.
+Path to a sandbox definition file for overriding its configuration when you refresh it.
 
 # flags.definitionFile.description
 
-The sandbox definition file is a blueprint for the sandbox, and is used to change the configuration during a refresh. If no configuration changes from the sandbox creation are desired then simply target the sandbox org using the `--name` flag. See <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_sandbox_definition.htm> for all the options you can specify in the definition file.
+The sandbox definition file is a blueprint for the sandbox; use the file to change the sandbox configuration during a refresh. If you don't want to change the sandbox configuration when you refresh it, then simply use the --name flag to specify the sandbox and don't use this flag. See <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_sandbox_definition.htm> for all the options you can specify in the definition file.
 
 # flags.name.summary
 
-Name of the existing sandbox org in your production org.
-
-# flags.name.description
-
-Name of the existing sandbox org in your production org.
+Name of the existing sandbox org in your production org that you want to refresh.
 
 # flags.wait.summary
 
@@ -76,7 +64,7 @@ The command immediately displays the job ID and returns control of the terminal 
 
 # flags.noPrompt.summary
 
-Don't prompt for confirmation about the sandbox configuration.
+Don't prompt for confirmation about the sandbox refresh.
 
 # isConfigurationOk
 
@@ -84,7 +72,7 @@ Is the configuration correct?
 
 # error.SandboxNameLength
 
-The sandbox name "%s" should be 10 or fewer characters.
+The sandbox name "%s" must be 10 or fewer characters.
 
 # error.NoSandboxName
 
@@ -92,7 +80,7 @@ Must specify a sandbox name using the `--name` or `--definition-file` flag.
 
 # warning.ConflictingSandboxNames
 
-Different sandbox names were provided with the `--name` ('%s') and `--definition-file` flags ('%s'). Using the value provided by the `--name` flag. If you want to change the name of the sandbox, please delete and create using the new name.
+Different sandbox names were provided with the `--name` ('%s') and `--definition-file` flags ('%s'). Using the value provided by the `--name` flag. If you want to change the name of the sandbox, first delete it and then create it again using the new name.
 
 # error.SandboxNotFound
 
@@ -109,7 +97,7 @@ The sandbox request configuration isn't acceptable.
 
 # error.pollIntervalGreaterThanWait
 
-The poll interval (%d seconds) can't be larger that wait (%d in seconds)
+The poll interval (%d seconds) can't be larger than the wait period (%d in seconds).
 
 # sandboxInfoRefreshFailed
 

--- a/src/commands/org/refresh/sandbox.ts
+++ b/src/commands/org/refresh/sandbox.ts
@@ -50,7 +50,6 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxProcessObj
   public static flags = {
     'auto-activate': Flags.boolean({
       summary: messages.getMessage('flags.auto-activate.summary'),
-      description: messages.getMessage('flags.auto-activate.description'),
       default: true,
       allowNo: true,
     }),
@@ -81,7 +80,6 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxProcessObj
     name: Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.name.summary'),
-      description: messages.getMessage('flags.name.description'),
       parse: (name: string): Promise<string> => {
         if (name.length > 10) {
           throw messages.createError('error.SandboxNameLength', [name]);
@@ -98,7 +96,6 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxProcessObj
     'target-org': Flags.requiredOrg({
       char: 'o',
       summary: messages.getMessage('flags.targetOrg.summary'),
-      description: messages.getMessage('flags.targetOrg.description'),
       required: true,
     }),
     'no-prompt': Flags.boolean({


### PR DESCRIPTION
### What does this PR do?

Edit messages for new "org refresh sandbox" command.  Also adds info and exmaple about cloning a sandbox to the "org create sandbox" messages -- I noticed it was missing. 

### What issues does this PR fix or reference?
@W-15134034@