### PR TITLE
fix: fix NUTs for sbx refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"./test/nut/sandboxRefresh.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
+    "test:nuts": "nyc mocha \"./test/nut/sandboxRefresh.nut.ts\" --slow 4500 --timeout 1200000",
     "test:nuts:legacy": "nyc mocha \"./test/nut/legacy/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:sandbox": "nyc mocha \"./test/**/*.sandboxNut.ts\" --slow 450000 --timeout 7200000 --parallel --jobs 5",
     "test:only": "wireit",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"./test/nut/sandboxRefresh.nut.ts\" --slow 4500 --timeout 1200000",
+    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:legacy": "nyc mocha \"./test/nut/legacy/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:sandbox": "nyc mocha \"./test/**/*.sandboxNut.ts\" --slow 450000 --timeout 7200000 --parallel --jobs 5",
     "test:only": "wireit",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
+    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000",
     "test:nuts:legacy": "nyc mocha \"./test/nut/legacy/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:sandbox": "nyc mocha \"./test/**/*.sandboxNut.ts\" --slow 450000 --timeout 7200000 --parallel --jobs 5",
     "test:only": "wireit",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000",
+    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:legacy": "nyc mocha \"./test/nut/legacy/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:sandbox": "nyc mocha \"./test/**/*.sandboxNut.ts\" --slow 450000 --timeout 7200000 --parallel --jobs 5",
     "test:only": "wireit",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"./test/nut/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
+    "test:nuts": "nyc mocha \"./test/nut/sandboxRefresh.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:legacy": "nyc mocha \"./test/nut/legacy/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --jobs 5",
     "test:nuts:sandbox": "nyc mocha \"./test/**/*.sandboxNut.ts\" --slow 450000 --timeout 7200000 --parallel --jobs 5",
     "test:only": "wireit",

--- a/test/nut/async-create-resume.nut.ts
+++ b/test/nut/async-create-resume.nut.ts
@@ -7,7 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { execCmd, TestSession, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import { assert, expect } from 'chai';
 import { AuthFields, Global, ScratchOrgCache } from '@salesforce/core';
 import { CachedOptions } from '@salesforce/core/lib/org/scratchOrgCache.js';
@@ -37,8 +37,10 @@ describe('env:create:scratch async/resume', () => {
   };
 
   before(async () => {
+    const uid = genUniqueString('acr_%s');
     session = await TestSession.create({
       project: { name: 'asyncCreateResume' },
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
       devhubAuthStrategy: 'AUTO',
     });
     cacheFilePath = path.join(session.dir, '.sf', ScratchOrgCache.getFileName());

--- a/test/nut/listAndDisplay.nut.ts
+++ b/test/nut/listAndDisplay.nut.ts
@@ -8,7 +8,7 @@
 import { join } from 'node:path';
 import os from 'node:os';
 import { expect, config, assert } from 'chai';
-import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { TestSession, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
 import { OrgListResult, defaultHubEmoji, defaultOrgEmoji } from '../../src/commands/org/list.js';
 import { OrgOpenOutput } from '../../src/commands/org/open.js';
@@ -52,8 +52,10 @@ describe('Org Command NUT', () => {
   let aliasUserOrgId: string;
 
   before(async () => {
+    const uid = genUniqueString('listAndDisplay_%s');
     session = await TestSession.create({
       project: { name: 'listAndDisplay' },
+      sessionDir: join(process.cwd(), `test_session_${uid}`),
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {

--- a/test/nut/metadata.nut.ts
+++ b/test/nut/metadata.nut.ts
@@ -7,17 +7,19 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { expect } from 'chai';
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { execCmd, TestSession, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import type { DescribeMetadataResult } from 'jsforce/lib/api/metadata/schema.js';
 import type { ListMetadataCommandResult } from '../../src/commands/org/list/metadata.js';
 
 describe('org list metadata*', () => {
   let session: TestSession;
   before(async () => {
+    const uid = genUniqueString('listMetadata_%s');
     session = await TestSession.create({
       project: {
         gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
       },
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {

--- a/test/nut/open.nut.ts
+++ b/test/nut/open.nut.ts
@@ -7,7 +7,7 @@
 
 import path from 'node:path';
 import fs from 'node:fs';
-import { TestSession, execCmd } from '@salesforce/cli-plugins-testkit';
+import { TestSession, execCmd, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import { expect, config, assert } from 'chai';
 import { AuthFields } from '@salesforce/core';
 import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
@@ -24,10 +24,12 @@ describe('test org:open command', () => {
   const flowPath = path.join('force-app', 'main', 'default', 'flows', 'Create_property.flow-meta.xml');
 
   before(async () => {
+    const uid = genUniqueString('orgOpen_%s');
     session = await TestSession.create({
       project: {
         gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
       },
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -337,7 +337,7 @@ describe('Sandbox Refresh', () => {
 
     // Stub AuthInfo functions so an auth file is written without making http calls
     // @ts-expect-error stubbing private function
-    const authInfoCreateStub = sinonSandbox.stub(AuthInfo.prototype, 'exchangeToken').resolves({
+    const authInfoExchangeTokenStub = sinonSandbox.stub(AuthInfo.prototype, 'exchangeToken').resolves({
       username: sbxAuthResponse.authUserName,
       parentUsername: hubOrgUsername,
       instanceUrl: sbxAuthResponse.instanceUrl,
@@ -369,7 +369,9 @@ describe('Sandbox Refresh', () => {
     expect(toolingQueryStub.calledOnce, 'toolingQueryStub called').to.be.true;
     expect(querySandboxProcessByIdStub.called, 'querySandboxProcessByIdStub called').to.be.true;
     expect(sandboxSignupCompleteStub.called, 'sandboxSignupCompleteStub called').to.be.true;
-    expect(authInfoCreateStub.called, 'authInfoCreateStub called').to.be.true;
+    // expect(authInfoExchangeTokenStub.called, 'authInfoExchangeTokenStub called').to.be.true;
+    // eslint-disable-next-line no-console
+    console.dir(authInfoExchangeTokenStub, { depth: 8 });
 
     // Check auth files exist
     const authFileContents = readAuthFile(session.homeDir, sbxAuthResponse.authUserName);

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -350,6 +350,8 @@ describe('Sandbox Refresh', () => {
     // @ts-expect-error stubbing private function
     sinonSandbox.stub(AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
+    const authInfoCreateSpy = sinonSandbox.spy(AuthInfo, 'create');
+
     const result: SandboxProcessObject = await RefreshSandbox.run([
       '--name',
       sbxName,
@@ -371,7 +373,14 @@ describe('Sandbox Refresh', () => {
     expect(sandboxSignupCompleteStub.called, 'sandboxSignupCompleteStub called').to.be.true;
     // expect(authInfoExchangeTokenStub.called, 'authInfoExchangeTokenStub called').to.be.true;
     // eslint-disable-next-line no-console
-    console.dir(authInfoExchangeTokenStub, { depth: 8 });
+    console.log(authInfoCreateSpy.callCount);
+    // eslint-disable-next-line no-console
+    console.dir(authInfoCreateSpy.firstCall.args);
+    // eslint-disable-next-line no-console
+    console.dir(authInfoCreateSpy.secondCall.args);
+    // eslint-disable-next-line no-console
+    console.dir(authInfoCreateSpy.thirdCall.args);
+    assert(authInfoExchangeTokenStub);
 
     // Check auth files exist
     const authFileContents = readAuthFile(session.homeDir, sbxAuthResponse.authUserName);

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -302,7 +302,7 @@ describe('Sandbox Refresh', () => {
     expect(sfCommandUxStubs.info.firstCall.args[0]).to.equal(sbxStatusMsg);
   });
 
-  it.only('should poll and report a success and write an auth file', async () => {
+  it('should poll and report a success and write an auth file', async () => {
     const sbxInfo = getSandboxInfo();
     const sbxName = sbxInfo.SandboxName;
     const sbxProcess = getSandboxProcess();
@@ -350,8 +350,6 @@ describe('Sandbox Refresh', () => {
     // @ts-expect-error stubbing private function
     sinonSandbox.stub(AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
-    const authInfoCreateSpy = sinonSandbox.spy(AuthInfo, 'create');
-
     const result: SandboxProcessObject = await RefreshSandbox.run([
       '--name',
       sbxName,
@@ -371,16 +369,7 @@ describe('Sandbox Refresh', () => {
     expect(toolingQueryStub.calledOnce, 'toolingQueryStub called').to.be.true;
     expect(querySandboxProcessByIdStub.called, 'querySandboxProcessByIdStub called').to.be.true;
     expect(sandboxSignupCompleteStub.called, 'sandboxSignupCompleteStub called').to.be.true;
-    // expect(authInfoExchangeTokenStub.called, 'authInfoExchangeTokenStub called').to.be.true;
-    // eslint-disable-next-line no-console
-    console.log(authInfoCreateSpy.callCount);
-    // eslint-disable-next-line no-console
-    console.dir(authInfoCreateSpy.firstCall.args);
-    // eslint-disable-next-line no-console
-    console.dir(authInfoCreateSpy.secondCall.args);
-    // eslint-disable-next-line no-console
-    console.dir(authInfoCreateSpy.thirdCall.args);
-    assert(authInfoExchangeTokenStub);
+    expect(authInfoExchangeTokenStub.called, 'authInfoExchangeTokenStub called').to.be.true;
 
     // Check auth files exist
     const authFileContents = readAuthFile(session.homeDir, sbxAuthResponse.authUserName);

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -46,7 +46,7 @@ describe('Sandbox Refresh', () => {
     const uid = genUniqueString('sbxRefresh_%s');
     session = await TestSession.create({
       project: { name: 'sandboxRefresh' },
-      devhubAuthStrategy: 'AUTO',
+      devhubAuthStrategy: 'AUTH_URL',
       sessionDir: path.join(process.cwd(), `test_session_${uid}`),
     });
     assert(session.hubOrg.username);

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -30,7 +30,7 @@ import {
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'sandboxbase');
 
-describe.skip('Sandbox Refresh', () => {
+describe('Sandbox Refresh', () => {
   let session: TestSession;
   let hubOrgUsername: string;
   let cacheFilePath: string;
@@ -190,6 +190,7 @@ describe.skip('Sandbox Refresh', () => {
 
     try {
       await RefreshSandbox.run(['--name', sbxName, '-o', hubOrgUsername, '--async', '--json']);
+      assert(false, 'Expected SandboxNotFoundError');
     } catch (e) {
       assert(e instanceof SfError, 'Expect error to be an instance of SfError');
       expect(e.name).to.equal('SandboxNotFoundError');
@@ -299,7 +300,7 @@ describe.skip('Sandbox Refresh', () => {
     expect(sfCommandUxStubs.info.firstCall.args[0]).to.equal(sbxStatusMsg);
   });
 
-  it.skip('should poll and report a success and write an auth file', async () => {
+  it('should poll and report a success and write an auth file', async () => {
     const sbxInfo = getSandboxInfo();
     const sbxName = sbxInfo.SandboxName;
     const sbxProcess = getSandboxProcess();

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -302,7 +302,7 @@ describe('Sandbox Refresh', () => {
     expect(sfCommandUxStubs.info.firstCall.args[0]).to.equal(sbxStatusMsg);
   });
 
-  it('should poll and report a success and write an auth file', async () => {
+  it.only('should poll and report a success and write an auth file', async () => {
     const sbxInfo = getSandboxInfo();
     const sbxName = sbxInfo.SandboxName;
     const sbxProcess = getSandboxProcess();

--- a/test/nut/scratchCreate.nut.ts
+++ b/test/nut/scratchCreate.nut.ts
@@ -29,9 +29,11 @@ describe('env create scratch NUTs', () => {
   };
 
   before(async () => {
+    const uid = genUniqueString('sbxCreate_%s');
     session = await TestSession.create({
       project: { name: 'scratchOrgCreate' },
       devhubAuthStrategy: 'AUTO',
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
     });
   });
 

--- a/test/nut/scratchDelete.nut.ts
+++ b/test/nut/scratchDelete.nut.ts
@@ -7,7 +7,7 @@
 
 import path from 'node:path';
 import fs from 'node:fs';
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { execCmd, TestSession, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import { assert, expect } from 'chai';
 import { ScratchDeleteResponse } from '../../src/commands/org/delete/scratch.js';
 
@@ -18,8 +18,10 @@ describe('org:delete:scratch NUTs', () => {
   let session: TestSession;
 
   before(async () => {
+    const uid = genUniqueString('scratchDelete_%s');
     session = await TestSession.create({
       project: { name: 'scratchOrgDelete' },
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {

--- a/test/nut/tracking.nut.ts
+++ b/test/nut/tracking.nut.ts
@@ -5,23 +5,25 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import path from 'node:path';
+import { execCmd, TestSession, genUniqueString } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Messages } from '@salesforce/core';
 import { OrgEnableTrackingResult } from '../../src/commands/org/enable/tracking.js';
 import { OrgDisableTrackingResult } from '../../src/commands/org/disable/tracking.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'org.enable.tracking');
 
 describe('org enable/disable tracking NUTs', () => {
   let session: TestSession;
 
   before(async () => {
+    const uid = genUniqueString('tracking_%s');
     session = await TestSession.create({
       devhubAuthStrategy: 'AUTO',
       project: { name: 'orgEnableDisableTrackingNut' },
+      sessionDir: path.join(process.cwd(), `test_session_${uid}`),
       scratchOrgs: [{ setDefault: true, edition: 'developer' }],
     });
   });

--- a/test/shared/sandboxMockUtils.ts
+++ b/test/shared/sandboxMockUtils.ts
@@ -74,12 +74,12 @@ export const updateSuccessResponse: SaveResult = {
   errors: [],
 };
 
-export const readSandboxCacheFile = async (cacheFilePath: string): Promise<Record<string, CachedOptions>> =>
-  JSON.parse(await fs.promises.readFile(cacheFilePath, 'utf8')) as unknown as Record<string, CachedOptions>;
-export const deleteSandboxCacheFile = async (cacheFilePath: string): Promise<void> => fs.promises.unlink(cacheFilePath);
-export const readAuthFile = async (homeDir: string, username: string): Promise<AuthFields> => {
+export const readSandboxCacheFile = (cacheFilePath: string): Record<string, CachedOptions> =>
+  JSON.parse(fs.readFileSync(cacheFilePath, 'utf8')) as unknown as Record<string, CachedOptions>;
+export const deleteSandboxCacheFile = (cacheFilePath: string): void => fs.unlinkSync(cacheFilePath);
+export const readAuthFile = (homeDir: string, username: string): AuthFields => {
   const filePath = path.join(homeDir, Global.STATE_FOLDER, `${username}.json`);
-  return JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as AuthFields;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as AuthFields;
 };
 export const getSandboxInfo = (overrides?: Partial<SandboxInfo>): SandboxInfo =>
   Object.assign({}, sandboxInfo, overrides);

--- a/test/shared/sandboxMockUtils.ts
+++ b/test/shared/sandboxMockUtils.ts
@@ -114,7 +114,7 @@ export const stubProdOrgConnection = async (
     .stub(Org, 'create')
     .withArgs({ aliasOrUsername: username })
     .callsFake(async (opts) => {
-      const org = (await orgCreateFn.call(Org, opts)) as Org;
+      const org = (await orgCreateFn(opts)) as Org;
       // @ts-expect-error re-assigning a private property
       org.connection = connection;
       return org;


### PR DESCRIPTION
Changes the sandbox refresh and create NUTs to ensure a unique TestSession dir.

[skip-validate-pr]