### PR TITLE
test: change to no-auto-activate flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -187,10 +187,10 @@
     "flagChars": ["f", "i", "n", "o", "w"],
     "flags": [
       "async",
-      "auto-activate",
       "definition-file",
       "json",
       "name",
+      "no-auto-activate",
       "no-prompt",
       "poll-interval",
       "target-org",

--- a/messages/refresh.sandbox.md
+++ b/messages/refresh.sandbox.md
@@ -22,9 +22,13 @@ You're not allowed to change the sandbox name when you refresh it with this comm
 
   <%= config.bin %> <%= command.id %> --definition-file devSbx3-config.json --target-org prodOrg
 
-# flags.auto-activate.summary
+# flags.no-auto-activate.summary
 
-Activates the sandbox after a successful refresh.
+Disable auto-activation of the sandbox after a successful refresh.
+
+# flags.no-auto-activate.description
+
+By default, a sandbox auto-activates after a refresh. Use this flag to control sandbox activation manually.
 
 # flags.targetOrg.summary
 

--- a/src/commands/org/refresh/sandbox.ts
+++ b/src/commands/org/refresh/sandbox.ts
@@ -47,10 +47,9 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxProcessObj
   public static examples = messages.getMessages('examples');
 
   public static flags = {
-    'auto-activate': Flags.boolean({
-      summary: messages.getMessage('flags.auto-activate.summary'),
-      default: true,
-      allowNo: true,
+    'no-auto-activate': Flags.boolean({
+      summary: messages.getMessage('flags.no-auto-activate.summary'),
+      description: messages.getMessage('flags.no-auto-activate.description'),
     }),
     wait: Flags.duration({
       char: 'w',
@@ -214,7 +213,7 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxProcessObj
     // assign overrides
     sandboxInfo = Object.assign(sandboxInfo, defFileContent, {
       SandboxName: sbxName,
-      AutoActivate: this.flags['auto-activate'],
+      AutoActivate: !this.flags['no-auto-activate'],
     });
 
     return sandboxInfo;


### PR DESCRIPTION
### What does this PR do?
Changes the `auto-activate` flag to `no-auto-activate` since that is the only valid way to disable the default behavior anyway. 

### What issues does this PR fix or reference?
@W-15042183@