### PR TITLE
Use homefolder for `org open` under linux to prevent issues with sandboxing through snap

### DIFF
--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -130,7 +130,15 @@ export class OrgOpenCommand extends SfCommand<OrgOpenOutput> {
     }
 
     // create a local html file that contains the POST stuff.
-    const tempFilePath = path.join(tmpdir(), `org-open-${new Date().valueOf()}.html`);
+    let tempFilePath = path.join(tmpdir(), `org-open-${new Date().valueOf()}.html`);
+
+    if( platform() === 'linux'){
+        // on linux create the temp file in the home folder as e.g. snaps can not access /tmp
+        let folderPath = path.join(homedir(), `temp`);
+        await fs.promises.mkdir(folderPath, { recursive: true });
+        tempFilePath = path.join(homedir(), `temp`, `org-open-${new Date().valueOf()}.html`);
+    }
+    
     await fs.promises.writeFile(
       tempFilePath,
       getFileContents(


### PR DESCRIPTION
### What does this PR do?
Currently `sf org open` creates a file under `/tmp` (base on TMPDIR/TMP environment vars). The `/tmp` folder is not visible to snaps due to sandboxing. Snaps are the recommended distribution for Firefox under Ubuntu.

Instead of creating a file under `tmp` this creates the file under the homefolder in a subdirectory called `temp`. `/home/.tmp` also does not work, as snaps can not see hidden folders. The temp files could also be created under `/home` directly, as they are deleted either way.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2769