### PR TITLE
fix: typo in description

### DIFF
--- a/messages/refresh.sandbox.md
+++ b/messages/refresh.sandbox.md
@@ -4,7 +4,7 @@ Refresh a sandbox org using the sandbox name.
 
 # description
 
-Refreshing a sandbox copies the metadata, and optionally data, from your production org to the refreshed sandbox org. You can optionally specify a definition file if you want to change the configuration of the refreshed sandbox, such as its license type or template ID.
+Refreshing a sandbox copies the metadata, and optionally data, from your source org to the refreshed sandbox org. You can optionally specify a definition file if you want to change the configuration of the refreshed sandbox, such as its license type or template ID.
 
 You're not allowed to change the sandbox name when you refresh it with this command. If you want to change the sandbox name, first delete it with the "org delete sandbox" command. And then recreate it with the "org create sandbox" command and give it a new name.
 


### PR DESCRIPTION
### What does this PR do?

Fixes typo in description that says "production org" instead of "source org". 

### What issues does this PR fix or reference?

@W-15458307@