### PR TITLE
Wr/cache miss

### DIFF
--- a/messages/resume_scratch.md
+++ b/messages/resume_scratch.md
@@ -4,9 +4,11 @@ Resume the creation of an incomplete scratch org.
 
 # description
 
-When the original "<%= config.bin %> org create scratch" command either times out or is run with the --async flag, it displays a job ID.
+When the original "<%= config.bin %> org create scratch" command either times out or is run with the --async flag, it
+displays a job ID.
 
-Run this command by either passing it a job ID or using the --use-most-recent flag to specify the most recent incomplete scratch org.
+Run this command by either passing it a job ID or using the --use-most-recent flag to specify the most recent incomplete
+scratch org.
 
 # examples
 
@@ -35,6 +37,10 @@ Use the job ID of the most recent incomplete scratch org.
 # error.NoRecentJobId
 
 There are no recent job IDs (ScratchOrgInfo requests) in your cache. Maybe it completed or already resumed?
+
+# error.jobIdMismatch
+
+There are no recent job IDs (ScratchOrgInfo requests) in your cache that match %s. Maybe it completed?
 
 # success
 

--- a/src/commands/org/create/scratch.ts
+++ b/src/commands/org/create/scratch.ts
@@ -6,26 +6,25 @@
  */
 
 import {
-  Messages,
   Lifecycle,
-  ScratchOrgLifecycleEvent,
-  scratchOrgLifecycleEventName,
+  Messages,
   Org,
   scratchOrgCreate,
+  ScratchOrgLifecycleEvent,
+  scratchOrgLifecycleEventName,
   SfError,
 } from '@salesforce/core';
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
 import { Duration } from '@salesforce/kit';
 import { buildScratchOrgRequest } from '../../../shared/scratchOrgRequest.js';
 import { buildStatus } from '../../../shared/scratchOrgOutput.js';
 import { ScratchCreateResponse } from '../../../shared/orgTypes.js';
+
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'create_scratch');
 
-export const secretTimeout = 60_000;
-
 const definitionFileHelpGroupName = 'Definition File Override';
-export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+export default class OrgCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
@@ -158,7 +157,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 
   public async run(): Promise<ScratchCreateResponse> {
     const lifecycle = Lifecycle.getInstance();
-    const { flags } = await this.parse(EnvCreateScratch);
+    const { flags } = await this.parse(OrgCreateScratch);
     const baseUrl = flags['target-dev-hub'].getField(Org.Fields.INSTANCE_URL)?.toString();
     if (!baseUrl) {
       throw new SfError('No instance URL found for the dev hub');

--- a/src/commands/org/resume/scratch.ts
+++ b/src/commands/org/resume/scratch.ts
@@ -23,7 +23,7 @@ import { buildStatus } from '../../../shared/scratchOrgOutput.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-org', 'resume_scratch');
 
-export default class EnvResumeScratch extends SfCommand<ScratchCreateResponse> {
+export default class OrgResumeScratch extends SfCommand<ScratchCreateResponse> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
@@ -46,7 +46,7 @@ export default class EnvResumeScratch extends SfCommand<ScratchCreateResponse> {
   };
 
   public async run(): Promise<ScratchCreateResponse> {
-    const { flags } = await this.parse(EnvResumeScratch);
+    const { flags } = await this.parse(OrgResumeScratch);
     const cache = await ScratchOrgCache.create();
     const lifecycle = Lifecycle.getInstance();
 
@@ -81,7 +81,6 @@ export default class EnvResumeScratch extends SfCommand<ScratchCreateResponse> {
       } else {
         throw SfError.wrap(e);
       }
-      return {} as ScratchCreateResponse;
     }
   }
 }

--- a/src/commands/org/resume/scratch.ts
+++ b/src/commands/org/resume/scratch.ts
@@ -7,14 +7,15 @@
 
 import { strict as assert } from 'node:assert';
 
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
 import {
-  Messages,
-  scratchOrgResume,
-  ScratchOrgCache,
   Lifecycle,
+  Messages,
+  ScratchOrgCache,
   ScratchOrgLifecycleEvent,
   scratchOrgLifecycleEventName,
+  scratchOrgResume,
+  SfError,
 } from '@salesforce/core';
 import { ScratchCreateResponse } from '../../../shared/orgTypes.js';
 import { buildStatus } from '../../../shared/scratchOrgOutput.js';
@@ -54,7 +55,7 @@ export default class EnvResumeScratch extends SfCommand<ScratchCreateResponse> {
 
     // oclif doesn't know that the exactlyOne flag will ensure that one of these is set, and there we definitely have a jobID.
     assert(jobId);
-    const { hubBaseUrl } = cache.get(jobId);
+    const hubBaseUrl = cache.get(jobId)?.hubBaseUrl;
     let lastStatus: string | undefined;
 
     lifecycle.on<ScratchOrgLifecycleEvent>(scratchOrgLifecycleEventName, async (data): Promise<void> => {
@@ -66,11 +67,21 @@ export default class EnvResumeScratch extends SfCommand<ScratchCreateResponse> {
     this.log();
     this.spinner.start('Creating Scratch Org');
 
-    const { username, scratchOrgInfo, authFields, warnings } = await scratchOrgResume(jobId);
-    this.spinner.stop(lastStatus);
+    try {
+      const { username, scratchOrgInfo, authFields, warnings } = await scratchOrgResume(jobId);
+      this.spinner.stop(lastStatus);
 
-    this.log();
-    this.logSuccess(messages.getMessage('success'));
-    return { username, scratchOrgInfo, authFields, warnings, orgId: authFields?.orgId };
+      this.log();
+      this.logSuccess(messages.getMessage('success'));
+      return { username, scratchOrgInfo, authFields, warnings, orgId: authFields?.orgId };
+    } catch (e) {
+      if (cache.keys() && (e as Error).name === 'CacheMissError') {
+        // we have something in the cache, but it didn't match what the user passed in
+        throw messages.createError('error.jobIdMismatch', [jobId]);
+      } else {
+        throw SfError.wrap(e);
+      }
+      return {} as ScratchCreateResponse;
+    }
   }
 }

--- a/test/unit/org/resumeScratch.test.ts
+++ b/test/unit/org/resumeScratch.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { config, expect } from 'chai';
+import sinon from 'sinon';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { Messages, ScratchOrgCache, SfError } from '@salesforce/core';
+
+import { stubSfCommandUx, stubUx } from '@salesforce/sf-plugins-core';
+import OrgResumeScratch from '../../../src/commands/org/resume/scratch.js';
+
+config.truncateThreshold = 0;
+
+describe('org:resume:scratch', () => {
+  Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+  const messages = Messages.loadMessages('@salesforce/plugin-org', 'resume_scratch');
+  const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    stubSfCommandUx(sandbox);
+    stubUx(sandbox);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('will handle a cache miss gracefully', async () => {
+    stubMethod(sandbox, ScratchOrgCache, 'create').resolves({
+      get: () => {},
+      keys: () => {},
+    });
+
+    try {
+      await OrgResumeScratch.run(['--job-id', '2SRFOOFOOFOOFOOFOO']);
+      expect(false, 'ResumeSandbox should have thrown sandboxCreateNotComplete');
+    } catch (err: unknown) {
+      const error = err as SfError;
+      expect(error.message).to.equal('The ScratchOrgInfoId 2SRFOOFOOFOOFOOFOO was not found in the cache.');
+      expect(error.name).to.equal('CacheMissError');
+    }
+  });
+
+  it('will handle a cache miss gracefully and change message when other keys exist', async () => {
+    stubMethod(sandbox, ScratchOrgCache, 'create').resolves({
+      get: () => {},
+      keys: () => ['abc', '123'],
+    });
+
+    try {
+      await OrgResumeScratch.run(['--job-id', '2SRFOOFOOFOOFOOFOO']);
+      expect(false, 'ResumeSandbox should have thrown sandboxCreateNotComplete');
+    } catch (err: unknown) {
+      const error = err as SfError;
+      expect(error.message).to.equal(messages.getMessage('error.jobIdMismatch', ['2SRFOOFOOFOOFOOFOO']));
+      expect(error.name).to.equal('JobIdMismatchError');
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

fixes ugly error when there's a cache miss

before
```bash
Error (10): Cannot destructure property 'hubBaseUrl' of 'cache.get(...)' as it is undefined.
```

after
```bash
There are no recent job IDs (ScratchOrgInfo requests) in your cache that match 2SRFOOFOOFOOFOOFOO. Maybe it completed?
```

refactors class names away from `env`

### What issues does this PR fix or reference?
@W-15818551@