### PR TITLE
fix: improve --target-org summaries of "org delete scratch|sandbox"

### DIFF
--- a/messages/delete_sandbox.md
+++ b/messages/delete_sandbox.md
@@ -24,7 +24,7 @@ Both the sandbox and the associated production org must already be authenticated
 
 # flags.target-org.summary
 
-Sandbox alias or login user.
+Username or alias of the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.no-prompt.summary
 

--- a/messages/delete_scratch.md
+++ b/messages/delete_scratch.md
@@ -23,7 +23,7 @@ Specify a scratch org with either the username or the alias you gave the scratch
 
 # flags.target-org.summary
 
-Scratch org alias or login user.
+Username or alias of the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.no-prompt.summary
 


### PR DESCRIPTION
### What does this PR do?

Sets the summary for --target-org for the org delete scratch|sandbox commands to be the same as other --target-org summaries.  These two commands dont' use the standard definition of the flag. 

### What issues does this PR fix or reference?
@W-15895281@