### PR TITLE
fix: ensure org display picks the correct record

### DIFF
--- a/src/commands/org/display.ts
+++ b/src/commands/org/display.ts
@@ -56,7 +56,8 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     const fields = authInfo.getFields(true) as AuthFieldsFromFS;
 
     const isScratchOrg = Boolean(fields.devHubUsername);
-    const scratchOrgInfo = isScratchOrg && fields.orgId ? await this.getScratchOrgInformation(fields.orgId) : {};
+    const scratchOrgInfo =
+      isScratchOrg && fields.orgId ? await this.getScratchOrgInformation(fields.orgId, fields.username) : {};
 
     const returnValue: OrgDisplayReturn = {
       // renamed properties
@@ -101,11 +102,15 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     });
   }
 
-  private async getScratchOrgInformation(orgId: string): Promise<ScratchOrgFields> {
+  private async getScratchOrgInformation(orgId: string, username: string): Promise<ScratchOrgFields> {
     const hubOrg = await this.org.getDevHubOrg();
     // we know this is a scratch org so it must have a hubOrg and that'll have a username
     const hubUsername = hubOrg?.getUsername() as string;
-    const result = (await OrgListUtil.retrieveScratchOrgInfoFromDevHub(hubUsername, [trimTo15(orgId)]))[0];
+    // this query can return multiple records that match the 15 char ID because `ScratchOrgInfo.ScratchOrg` isn't a case-sensitive field
+    // so we look for the record that matches the scratch org username in the auth file.
+    const result = (await OrgListUtil.retrieveScratchOrgInfoFromDevHub(hubUsername, [trimTo15(orgId)])).find(
+      (rec) => rec.SignupUsername === username
+    );
 
     if (result) {
       return {

--- a/src/shared/orgTypes.ts
+++ b/src/shared/orgTypes.ts
@@ -52,7 +52,6 @@ export type FullyPopulatedScratchOrgFields = ScratchOrgFields &
 
 // developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_scratchorginfo.htm
 export type ScratchOrgInfoSObject = {
-  Id: string;
   CreatedDate: string;
   Status: 'New' | 'Deleted' | 'Active' | 'Error';
   ExpirationDate: string;
@@ -63,7 +62,7 @@ export type ScratchOrgInfoSObject = {
   Namespace?: string;
   OrgName: string;
   SignupUsername: string;
-}
+};
 
 /** fields in the  */
 export type ScratchOrgFields = {
@@ -78,7 +77,7 @@ export type ScratchOrgFields = {
   snapshot?: string;
   lastUsed?: Date;
   signupUsername: string;
-}
+};
 
 export type OrgListFields = {
   connectedStatus?: string;
@@ -87,7 +86,7 @@ export type OrgListFields = {
   defaultMarker?: '(D)' | '(U)';
   attributes?: Record<string, unknown>;
   lastUsed?: Date;
-}
+};
 
 /** If the scratch org is resumed, but doesn't get very far in the process, it won't have much information on it */
 export type ScratchCreateResponse = {
@@ -96,7 +95,7 @@ export type ScratchCreateResponse = {
   authFields?: AuthFields;
   warnings: string[];
   orgId?: string;
-}
+};
 
 export enum SandboxLicenseType {
   developer = 'Developer',

--- a/test/unit/org/display.test.ts
+++ b/test/unit/org/display.test.ts
@@ -200,6 +200,7 @@ describe('org:display', () => {
             Edition: 'Developer',
             OrgName: 'MyOrg',
             CreatedDate: '2020-12-24T15:18:55.000+0000',
+            SignupUsername: testOrg.username,
           },
         ]),
     });


### PR DESCRIPTION
### What does this PR do?

Fix a bug where `org display` would return wrong info about a scratch org when its 15-char ID matches other `ScratchOrgInfo` records in the hub.

the query runs here:
https://github.com/salesforcecli/plugin-org/blob/49c4e33cf3a612b4f2344f0d0fe11aa0de3e223a/src/shared/orgListUtil.ts#L244C1-L251C43

and gets translated to this SOQL query:
```sql
SELECT CreatedDate, Edition, Status, ExpirationDate, Namespace, OrgName, CreatedBy.Username, SignupUsername FROM ScratchOrgInfo WHERE ScratchOrg IN ('org-id')
```

The `IN` operator is case-sensitive if the fields it operates on are, `ScratchOrgInfo.ScratchOrg` **is not**:
```
sf sobject describe --sobject ScratchOrgInfo --target-org na40 --json | jq '.result.fields | .[] | select (.name == "ScratchOrg") | .caseSensitive'

> false
```

https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_conditionexpression.htm
> Operators that compare values, such as =,<=, IN, and LIKE. Operators are case insensitive for most fields, but case sensitive for case-sensitive fields.

We now look in the array of returned records for the one that matches the username from the auth file.

Slack thread: https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1719501479180489

## Testing

You'll need a scratch org with an ID that matches other records in the hub, since that's out of control you can partially repro this by creating a scratch org  using the na40 hub and then modify its auth file and set this org ID:
```
00D8K0000016nErUAI
```

running `sf org display` will show a deleted scratch org with this data:
```
...
 Signup Username test-taa4gxvtq9cc@example.com
 Status          Deleted
...
```
note that the signup username is different from the one in your auth file (printed a few lines below as `username`)

with this branch linked, `org display` will fail saying it can't find the org because the record doesn't match with your local username.

There's also a UT that covers this scenario.


### What issues does this PR fix or reference?
@W-16114810@
