### PR TITLE
fix(flags): no `dependsOn` boolean flags

### DIFF
--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -48,7 +48,14 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
     'no-prompt': Flags.boolean({
       char: 'p',
       summary: messages.getMessage('flags.no-prompt.summary'),
-      dependsOn: ['clean'],
+      // a
+      relationships: [
+        {
+          type: 'some',
+          // eslint-disable-next-line @typescript-eslint/require-await
+          flags: [{ name: 'clean', when: async (flags): Promise<boolean> => Promise.resolve(flags['clean'] === true) }],
+        },
+      ],
       aliases: ['noprompt'],
       deprecateAliases: true,
     }),

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -48,11 +48,9 @@ export class OrgListCommand extends SfCommand<OrgListResult> {
     'no-prompt': Flags.boolean({
       char: 'p',
       summary: messages.getMessage('flags.no-prompt.summary'),
-      // a
       relationships: [
         {
           type: 'some',
-          // eslint-disable-next-line @typescript-eslint/require-await
           flags: [{ name: 'clean', when: async (flags): Promise<boolean> => Promise.resolve(flags['clean'] === true) }],
         },
       ],


### PR DESCRIPTION
### What does this PR do?

Updates `--no-prompt` flag in `org list` to use oclif's relationship feature instead of `dependsOn` a boolean flag.
Found by the new eslint rule:
https://github.com/salesforcecli/eslint-plugin-sf-plugin/actions/runs/10097996137/job/27924153782?pr=447

no behavior change because `--no-prompt` was dependingOn `--clean` which didn't have a default value so it was working as expected:
```
➜  sf sf org list --no-prompt
Error (2): The following error occurred:
  All of the following must be provided when using --no-prompt: --clean
See more help with --help
```

### What issues does this PR fix or reference?
@W-16320656@
