### PR TITLE
edit messages of "org api rest"

### DIFF
--- a/messages/rest.md
+++ b/messages/rest.md
@@ -1,27 +1,24 @@
 # summary
 
-Makes an authenticated HTTP request to the Salesforce REST API and prints the response.
-
-# description
-
-You must specify a Salesforce org to use, either with the --target-org flag or by setting your default org with
-the `target-org` configuration variable.
+Make an authenticated HTTP request to Salesforce REST API and print the response.
 
 # examples
 
-- List information about limits in your org <%= config.bin %> <%= command.id %> 'services/data/v56.0/limits'
-  --target-org my-org
-- Get response in XML format by specifying the "Accept" HTTP header:
-  <%= config.bin %> <%= command.id %> 'services/data/v56.0/limits' --target-org my-org --header 'Accept:
-  application/xml',
+- List information about limits in the org with alias "my-org":
+
+    <%= config.bin %> <%= command.id %> 'services/data/v56.0/limits' --target-org my-org
+
+- Get the response in XML format by specifying the "Accept" HTTP header:
+
+    <%= config.bin %> <%= command.id %> 'services/data/v56.0/limits' --target-org my-org --header 'Accept: application/xml',
 
 # flags.include.summary
 
-Include HTTP response status and headers in the output.
+Include the HTTP response status and headers in the output.
 
 # flags.method.summary
 
-The HTTP method for the request.
+HTTP method for the request.
 
 # flags.header.summary
 
@@ -29,8 +26,8 @@ HTTP header in "key:value" format.
 
 # flags.stream-to-file.summary
 
-Stream responses to file.
+Stream responses to a file.
 
 # flags.body.summary
 
-The file to use as the body for the request (use "-" to read from standard input, use "" for an empty body).
+File to use as the body for the request. Specify "-" to read from standard input; specify "" for an empty body.

--- a/src/commands/org/api/rest.ts
+++ b/src/commands/org/api/rest.ts
@@ -19,7 +19,6 @@ const messages = Messages.loadMessages('@salesforce/plugin-org', 'rest');
 
 export class Rest extends SfCommand<void> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly hidden = true;
   public static enableJsonFlag = false;


### PR DESCRIPTION
### What does this PR do?

quick edit of messages for hidden command "org api rest". note that I removed the command description because we don't restate that --target-org is required, and there was nothing else in the description. That's fine, command descriptions are optional.  If there's something else to say please add it back!

### What issues does this PR fix or reference?
@W-16451172@
