### PR TITLE
Open bot via the `--source-file` flag

### DIFF
--- a/messages/open.md
+++ b/messages/open.md
@@ -6,7 +6,7 @@ Open your default scratch org, or another specified org, in a browser.
 
 To open a specific page, specify the portion of the URL after "https://mydomain.my.salesforce.com" as the value for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
 
-Use the --source-file flag to open an ApexPage, FlexiPage, Flow, or Bot from your local project in the associated Builder within the Org.
+Use the --source-file flag to open ApexPage, FlexiPage, Flow, or Agent metadata from your local project in the associated Builder within the Org.
 
 To generate a URL but not launch it in your browser, specify --url-only.
 
@@ -38,7 +38,7 @@ To open in a specific browser, use the --browser flag. Supported browsers are "c
 
   $ <%= config.bin %> <%= command.id %> --source-file force-app/main/default/flows/Hello.flow-meta.xml
 
-- Open a local Bot in Bot Builder:
+- Open local Agent metadata (Bot) in Agent Builder:
 
   $ <%= config.bin %> <%= command.id %> --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml
 
@@ -52,7 +52,7 @@ Browser where the org opens.
 
 # flags.source-file.summary
 
-Path to an ApexPage, FlexiPage, Flow, or Bot to open in the associated Builder.
+Path to ApexPage, FlexiPage, Flow, or Agent metadata to open in the associated Builder.
 
 # flags.path.summary
 

--- a/messages/open.md
+++ b/messages/open.md
@@ -6,7 +6,7 @@ Open your default scratch org, or another specified org, in a browser.
 
 To open a specific page, specify the portion of the URL after "https://mydomain.my.salesforce.com" as the value for the --path flag. For example, specify "--path lightning" to open Lightning Experience, or specify "--path /apex/YourPage" to open a Visualforce page.
 
-Use the --source-file to open a Lightning Page from your local project in Lightning App Builder. Lightning page files have the suffix .flexipage-meta.xml, and are stored in the "flexipages" directory.
+Use the --source-file flag to open an ApexPage, FlexiPage, Flow, or Bot from your local project in the associated Builder within the Org.
 
 To generate a URL but not launch it in your browser, specify --url-only.
 
@@ -38,6 +38,10 @@ To open in a specific browser, use the --browser flag. Supported browsers are "c
 
   $ <%= config.bin %> <%= command.id %> --source-file force-app/main/default/flows/Hello.flow-meta.xml
 
+- Open a local Bot in Bot Builder:
+
+  $ <%= config.bin %> <%= command.id %> --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml
+
 # flags.private.summary
 
 Open the org in the default browser using private (incognito) mode.
@@ -48,7 +52,7 @@ Browser where the org opens.
 
 # flags.source-file.summary
 
-Path to an ApexPage or FlexiPage to open in Lightning App Builder.
+Path to an ApexPage, FlexiPage, Flow, or Bot to open in the associated Builder.
 
 # flags.path.summary
 
@@ -82,7 +86,7 @@ The Lightning Experience-enabled custom domain is unavailable.
 
 # FlowIdNotFound
 
-No ID not found for Flow %s.
+ID not found for Flow %s.
 
 # FlowIdNotFound.actions
 

--- a/src/commands/org/open.ts
+++ b/src/commands/org/open.ts
@@ -176,6 +176,8 @@ const generateFileUrl = async (file: string, conn: Connection): Promise<string> 
     const typeName = components[0]?.type?.name;
 
     switch (typeName) {
+      case 'Bot':
+        return `AiCopilot/copilotStudio.app#/copilot/builder?copilotId=${await botFileNameToId(conn, file)}`;
       case 'ApexPage':
         return `/apex/${path.basename(file).replace('.page-meta.xml', '').replace('.page', '')}`;
       case 'Flow':
@@ -192,6 +194,13 @@ const generateFileUrl = async (file: string, conn: Connection): Promise<string> 
     return 'lightning/setup/FlexiPageList/home';
   }
 };
+
+const botFileNameToId = async (conn: Connection, filePath: string): Promise<string> =>
+  (
+    await conn.singleRecordQuery<{ Id: string }>(
+      `SELECT id FROM BotDefinition WHERE DeveloperName='${path.basename(filePath, '.bot-meta.xml')}'`
+    )
+  ).Id;
 
 /** query flexipage via toolingPAI to get its ID (starts with 0M0) */
 const flexiPageFilenameToId = async (conn: Connection, filePath: string): Promise<string> =>
@@ -228,7 +237,7 @@ const getFileContents = (
   <body onload="document.body.firstElementChild.submit()">
     <form method="POST" action="${instanceUrl}/secur/frontdoor.jsp">
       <input type="hidden" name="sid" value="${authToken}" />
-      <input type="hidden" name="retURL" value="${retUrl}" /> 
+      <input type="hidden" name="retURL" value="${retUrl}" />
     </form>
   </body>
 </html>`;


### PR DESCRIPTION
### What does this PR do?
Will open the Bot Builder if you pass a `.bot-meta.xml` file to the `--source-file` flag.

Example:
`sf org open --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml`

https://github.com/user-attachments/assets/aa5af938-4190-4f5d-81a1-a9de998275a4

### What issues does this PR fix or reference?
[@W-16954218@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16954218)