### PR TITLE
fix: match on loginUrl/instanceUrl of ScratchOrgInfo if username does not match

### DIFF
--- a/src/commands/org/display.ts
+++ b/src/commands/org/display.ts
@@ -108,13 +108,12 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     const hubOrg = await this.org.getDevHubOrg();
     // we know this is a scratch org so it must have a hubOrg and that'll have a username
     const hubUsername = hubOrg?.getUsername() as string;
-    // Prefer the scratch org admin username if it's on the auth fields
-    const username = fields.scratchAdminUsername ?? fields.username;
+
     // This query can return multiple records that match the 15 char ID because `ScratchOrgInfo.ScratchOrg` isn't a case-sensitive field
     // so we look for the record that matches the scratch org username in the auth file.
     // If that doesn't match (e.g., when calling `org display` with a username that is not the scratch org admin), use the instance URL
     const result = (await OrgListUtil.retrieveScratchOrgInfoFromDevHub(hubUsername, [trimTo15(fields.orgId)])).find(
-      (rec) => rec.SignupUsername === username || rec.LoginUrl === fields.instanceUrl
+      (rec) => rec.SignupUsername === fields.username || rec.LoginUrl === fields.instanceUrl
     );
 
     if (result) {

--- a/src/commands/org/display.ts
+++ b/src/commands/org/display.ts
@@ -56,8 +56,7 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     const fields = authInfo.getFields(true) as AuthFieldsFromFS;
 
     const isScratchOrg = Boolean(fields.devHubUsername);
-    const scratchOrgInfo =
-      isScratchOrg && fields.orgId ? await this.getScratchOrgInformation(fields.orgId, fields.username) : {};
+    const scratchOrgInfo = isScratchOrg && fields.orgId ? await this.getScratchOrgInformation(fields) : {};
 
     const returnValue: OrgDisplayReturn = {
       // renamed properties
@@ -105,14 +104,17 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
     });
   }
 
-  private async getScratchOrgInformation(orgId: string, username: string): Promise<ScratchOrgFields> {
+  private async getScratchOrgInformation(fields: AuthFieldsFromFS): Promise<ScratchOrgFields> {
     const hubOrg = await this.org.getDevHubOrg();
     // we know this is a scratch org so it must have a hubOrg and that'll have a username
     const hubUsername = hubOrg?.getUsername() as string;
-    // this query can return multiple records that match the 15 char ID because `ScratchOrgInfo.ScratchOrg` isn't a case-sensitive field
+    // Prefer the scratch org admin username if it's on the auth fields
+    const username = fields.scratchAdminUsername ?? fields.username;
+    // This query can return multiple records that match the 15 char ID because `ScratchOrgInfo.ScratchOrg` isn't a case-sensitive field
     // so we look for the record that matches the scratch org username in the auth file.
-    const result = (await OrgListUtil.retrieveScratchOrgInfoFromDevHub(hubUsername, [trimTo15(orgId)])).find(
-      (rec) => rec.SignupUsername === username
+    // If that doesn't match (e.g., when calling `org display` with a username that is not the scratch org admin), use the instance URL
+    const result = (await OrgListUtil.retrieveScratchOrgInfoFromDevHub(hubUsername, [trimTo15(fields.orgId)])).find(
+      (rec) => rec.SignupUsername === username || rec.LoginUrl === fields.instanceUrl
     );
 
     if (result) {
@@ -128,8 +130,10 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
         signupUsername: result.SignupUsername,
       };
     }
-    throw new SfError(messages.getMessage('noScratchOrgInfoError', [trimTo15(orgId), hubUsername]), 'NoScratchInfo', [
-      messages.getMessage('noScratchOrgInfoAction'),
-    ]);
+    throw new SfError(
+      messages.getMessage('noScratchOrgInfoError', [trimTo15(fields.orgId), hubUsername]),
+      'NoScratchInfo',
+      [messages.getMessage('noScratchOrgInfoAction')]
+    );
   }
 }

--- a/src/shared/orgListUtil.ts
+++ b/src/shared/orgListUtil.ts
@@ -240,6 +240,7 @@ export class OrgListUtil {
       'OrgName',
       'CreatedBy.Username',
       'SignupUsername',
+      'LoginUrl',
     ];
 
     try {

--- a/src/shared/orgTypes.ts
+++ b/src/shared/orgTypes.ts
@@ -68,6 +68,7 @@ export type ScratchOrgInfoSObject = {
   Namespace?: string;
   OrgName: string;
   SignupUsername: string;
+  LoginUrl: string;
 };
 
 /** fields in the  */


### PR DESCRIPTION
### What does this PR do?
When running `sf org display` with a target-org that is not the scratch org admin user, the code would not match the ScratchOrgInfo SignupUser and would throw an error that the dev hub does not have a scratch org record with the provided org ID.  The code now tries to match the ScratchOrgInfo.LoginUrl with the target-org's instanceUrl as an additional way to match.  With this change, a user created within the scratch org can also have org details displayed when that user is the target-org username.

### What issues does this PR fix or reference?
@W-17545444@
