### PR TITLE
fix(org display): dont truncate table cells 

### DIFF
--- a/src/commands/org/display.ts
+++ b/src/commands/org/display.ts
@@ -95,6 +95,7 @@ export class OrgDisplayCommand extends SfCommand<OrgDisplayReturn> {
       }));
 
     this.table({
+      overflow: 'wrap',
       data: tableRows,
       columns: [
         { key: 'key', name: 'KEY' },


### PR DESCRIPTION
### What does this PR do?
Updates `org display` table to avoid truncating cells.
This table is pretty small (2 columns) so it doesn't change much other than helping see long values (`Sfdx Auth Url` and `Access Token` if using JWT-based ones).

Users can override the overflow behavior globally via `SF_TABLE_OVERFLOW`, this is more of a "sane default" for this specific table (bigger tables definitely need to wrap cells in some cases to be readable).
https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_env_variables.htm#sfdx_dev_cli_env_variables

### What issues does this PR fix or reference?
[skip-validate-pr]