### PR TITLE
fix: W-18237102 - refresh sandbox with sourceSandboxName

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -159,6 +159,8 @@
       "no-auto-activate",
       "no-prompt",
       "poll-interval",
+      "source-id",
+      "source-sandbox-name",
       "target-org",
       "wait"
     ],

--- a/messages/refresh.sandbox.md
+++ b/messages/refresh.sandbox.md
@@ -106,3 +106,33 @@ The poll interval (%d seconds) can't be larger than the wait period (%d in secon
 # sandboxInfoRefreshFailed
 
 The sandbox org refresh failed with a result of %s.
+
+# flags.source-sandbox-name.summary
+
+Name of the sandbox org to clone.
+
+# flags.source-sandbox-name.description
+
+The value of --source-sandbox-name must be an existing sandbox. The existing sandbox, and the new sandbox specified with the --name flag, must both be associated with the production org (--target-org) that contains the sandbox licenses.
+
+You can specify either --source-sandbox-name or --source-id when cloning an existing sandbox, but not both.
+
+# flags.source-id.summary
+
+ID of the sandbox org to clone.
+
+# flags.source-id.description
+
+The value of --source-id must be an existing sandbox. The existing sandbox, and the new sandbox specified with the --name flag, must both be associated with the production org (--target-org) that contains the sandbox licenses.
+
+# error.bothIdFlagAndDefFilePropertyAreProvided
+
+You can't specify both the --source-id and --definition-file flags, and also include the "SourceId" option in the definition file. Pick one method of cloning a sandbox and try again.
+
+# error.bothNameFlagAndDefFilePropertyAreProvided
+
+You can't specify both the --source-sandbox-name and --definition-file flags, and also include the "SourceSandboxName" option in the definition file. Pick one method of cloning a sandbox and try again.
+
+# error.bothIdFlagAndNameDefFileAreNotAllowed
+
+You can't specify both the --source-sandbox-name and --definition-file flags, and also include the "SourceId" option in the definition file. Same with the --source-id flag and "SourceSandboxName" option. Pick one method of cloning a sandbox and try again.

--- a/src/commands/org/refresh/sandbox.ts
+++ b/src/commands/org/refresh/sandbox.ts
@@ -190,6 +190,7 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxCommandRes
 
     let apexId: string | undefined;
     let groupId: string | undefined;
+    let srcId: string | undefined;
 
     if (defFileContent.ApexClassName) {
       apexId = await requestFunctions.getApexClassIdByName(
@@ -206,6 +207,15 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxCommandRes
       );
       delete defFileContent.ActivationUserGroupName;
     }
+
+    if (defFileContent.SourceSandboxName) {
+      srcId = await requestFunctions.getSrcIdByName(
+        this.flags['target-org'].getConnection(),
+        defFileContent.SourceSandboxName
+      );
+      delete defFileContent.SourceSandboxName;
+    }
+
     // Warn if sandbox name is in `--name` and `--definition-file` flags and they differ.
     if (defFileContent?.SandboxName && sbxName && sbxName !== defFileContent?.SandboxName) {
       this.warn(messages.createWarning('warning.ConflictingSandboxNames', [sbxName, defFileContent?.SandboxName]));
@@ -234,6 +244,7 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxCommandRes
       AutoActivate: !this.flags['no-auto-activate'],
       ...(apexId ? { ApexClassId: apexId } : {}),
       ...(groupId ? { ActivationUserGroupId: groupId } : {}),
+      ...(srcId ? { SourceId: srcId } : {}),
     });
 
     return sandboxInfo;

--- a/src/commands/org/refresh/sandbox.ts
+++ b/src/commands/org/refresh/sandbox.ts
@@ -79,7 +79,6 @@ export default class RefreshSandbox extends SandboxCommandBase<SandboxCommandRes
       description: messages.getMessage('flags.source-id.description'),
       exclusive: ['source-sandbox-name'],
       length: 'both',
-      char: undefined,
     }),
     async: Flags.boolean({
       summary: messages.getMessage('flags.async.summary'),


### PR DESCRIPTION
### What does this PR do?
fix issue: running` sf org refresh sandbox --name sbx --target-org prodOrgAlias` using `sourceSandboxName` to clone from different existing sandbox production.

it works with ` sourceId` and not `sourceSandboxName`. 

Add flag feature: `'source-id'` and `'source-sandbox-name'`.

**Note**: it should only be specify to use either one, but not both. Use flag or in the definition file to specify which existing sandbox to clone.

**Step to Reproduce**:

`sbx1` and `sbx2` created off production
`sbx3` which is a clone of `sbx1`
run `sf org refresh sandbox --name sbx3 --target-org prodOrgAlias --definition-file dev.json`

Inside `dev.json` file:
```
{
    "sourceSandboxName": "sbx2"
}
```
### What issues does this PR fix or reference?
@W-18237102@

see more details: https://github.com/forcedotcom/cli/issues/3262