### PR TITLE
test: remove getNamespacePrefix stubs for sfdx-core 8.31.0 W-22583951

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@oclif/core": "^4.11.3",
     "@oclif/multi-stage-output": "^0.8.40",
-    "@salesforce/core": "^8.29.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/kit": "^3.2.4",
     "@salesforce/sf-plugins-core": "^12.2.16",
     "@salesforce/source-deploy-retrieve": "^12.35.1",

--- a/schemas/org-create-scratch.json
+++ b/schemas/org-create-scratch.json
@@ -337,6 +337,9 @@
         },
         "trailExpirationDate": {
           "type": ["string", "null"]
+        },
+        "orgEdition": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/schemas/org-list.json
+++ b/schemas/org-list.json
@@ -183,6 +183,9 @@
         },
         "trailExpirationDate": {
           "type": ["string", "null"]
+        },
+        "orgEdition": {
+          "type": "string"
         }
       },
       "required": ["accessToken", "clientId", "instanceUrl", "orgId", "string", "username"]
@@ -339,6 +342,9 @@
         },
         "trailExpirationDate": {
           "type": ["string", "null"]
+        },
+        "orgEdition": {
+          "type": "string"
         },
         "createdBy": {
           "type": "string"

--- a/schemas/org-resume-scratch.json
+++ b/schemas/org-resume-scratch.json
@@ -337,6 +337,9 @@
         },
         "trailExpirationDate": {
           "type": ["string", "null"]
+        },
+        "orgEdition": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/test/nut/sandboxRefresh.nut.ts
+++ b/test/nut/sandboxRefresh.nut.ts
@@ -375,8 +375,6 @@ describe('Sandbox Refresh', () => {
     });
     // @ts-expect-error stubbing private function
     sinonSandbox.stub(AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-    // @ts-expect-error stubbing private function
-    sinonSandbox.stub(AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
     const result: SandboxProcessObject = await RefreshSandbox.run([
       '--name',

--- a/test/nut/sandboxResume.nut.ts
+++ b/test/nut/sandboxResume.nut.ts
@@ -174,8 +174,6 @@ describe('Sandbox Resume', () => {
     });
     // @ts-expect-error stubbing private function
     sinonSandbox.stub(AuthInfo.prototype, 'determineIfDevHub').resolves(false);
-    // @ts-expect-error stubbing private function
-    sinonSandbox.stub(AuthInfo.prototype, 'getNamespacePrefix').resolves();
 
     const result = await ResumeSandbox.run(['--job-id', sbxProcess.Id, '-o', hubOrgUsername, '--wait', '1', '--json']);
 

--- a/test/unit/org/open/agent.test.ts
+++ b/test/unit/org/open/agent.test.ts
@@ -123,10 +123,13 @@ describe('org:open:agent', () => {
       assert(response);
       testJsonStructure(response);
 
-      // Verify the BotDefinition query was made
-      expect(spies.get('singleRecordQuery').callCount).to.equal(1);
-      expect(spies.get('singleRecordQuery').firstCall.args[0]).to.include(mockBotName);
-      expect(spies.get('singleRecordQuery').firstCall.args[0]).to.include('BotDefinition');
+      // Verify the BotDefinition query was made (filter out determineOrg's Organization query)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const botCalls = spies
+        .get('singleRecordQuery')
+        .args.filter((args: string[]) => args[0].includes('BotDefinition'));
+      expect(botCalls).to.have.lengthOf(1);
+      expect(botCalls[0][0]).to.include(mockBotName);
 
       const expectedPath = `AiCopilot/copilotStudio.app#/copilot/builder?copilotId=${mockBotId}`;
       expect(response.url).to.equal(getExpectedUrlWithPath(expectedPath));
@@ -138,26 +141,36 @@ describe('org:open:agent', () => {
       testJsonStructure(response);
       expect(spies.get('requestGet').callCount).to.equal(1);
       expect(spies.get('open').callCount).to.equal(1);
-      expect(spies.get('singleRecordQuery').callCount).to.equal(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const botCalls = spies
+        .get('singleRecordQuery')
+        .args.filter((args: string[]) => args[0].includes('BotDefinition'));
+      expect(botCalls).to.have.lengthOf(1);
     });
 
     it('properly queries BotDefinition with special characters in api-name', async () => {
       const specialName = 'Test_Agent_01';
       await OrgOpenAgent.run(['--json', '--target-org', testOrg.username, '--url-only', '--api-name', specialName]);
 
-      expect(spies.get('singleRecordQuery').callCount).to.equal(1);
-      expect(spies.get('singleRecordQuery').firstCall.args[0]).to.include(specialName);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const botCalls = spies
+        .get('singleRecordQuery')
+        .args.filter((args: string[]) => args[0].includes('BotDefinition'));
+      expect(botCalls).to.have.lengthOf(1);
+      expect(botCalls[0][0]).to.include(specialName);
     });
 
     it('builds URL with api-name and version using BotVersion query', async () => {
       const version = '2';
-      // Override the singleRecordQuery stub to return different results for BotDefinition and BotVersion
+      // Override the singleRecordQuery stub to handle determineOrg, BotDefinition, and BotVersion
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const singleRecordQueryStub = spies.get('singleRecordQuery');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      singleRecordQueryStub.onFirstCall().resolves({ Id: mockBotId }); // BotDefinition query
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      singleRecordQueryStub.onSecondCall().resolves({ Id: mockVersionId }); // BotVersion query
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      singleRecordQueryStub.callsFake((query: string) => {
+        if (query.includes('FROM BotVersion')) return Promise.resolve({ Id: mockVersionId });
+        if (query.includes('FROM BotDefinition')) return Promise.resolve({ Id: mockBotId });
+        return Promise.resolve({});
+      });
 
       const response = await OrgOpenAgent.run([
         '--json',
@@ -172,17 +185,17 @@ describe('org:open:agent', () => {
       assert(response);
       testJsonStructure(response);
 
-      // Verify both queries were made
-      expect(singleRecordQueryStub.callCount).to.equal(2);
+      // Verify BotDefinition and BotVersion queries were made
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      const botDefCalls = singleRecordQueryStub.args.filter((args: string[]) => args[0].includes('FROM BotDefinition'));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      const botVerCalls = singleRecordQueryStub.args.filter((args: string[]) => args[0].includes('FROM BotVersion'));
+      expect(botDefCalls).to.have.lengthOf(1);
+      expect(botVerCalls).to.have.lengthOf(1);
 
-      // Verify BotDefinition query
-      expect(singleRecordQueryStub.firstCall.args[0]).to.include(mockBotName);
-      expect(singleRecordQueryStub.firstCall.args[0]).to.include('BotDefinition');
-
-      // Verify BotVersion query
-      expect(singleRecordQueryStub.secondCall.args[0]).to.include('BotVersion');
-      expect(singleRecordQueryStub.secondCall.args[0]).to.include(mockBotId);
-      expect(singleRecordQueryStub.secondCall.args[0]).to.include(`VersionNumber=${version}`);
+      expect(botDefCalls[0][0]).to.include(mockBotName);
+      expect(botVerCalls[0][0]).to.include(mockBotId);
+      expect(botVerCalls[0][0]).to.include(`VersionNumber=${version}`);
 
       const expectedPath = `AiCopilot/copilotStudio.app#/copilot/builder?copilotId=${mockBotId}&versionId=${mockVersionId}`;
       expect(response.url).to.equal(getExpectedUrlWithPath(expectedPath));
@@ -203,8 +216,12 @@ describe('org:open:agent', () => {
       assert(response);
       testJsonStructure(response);
 
-      // Verify no BotDefinition query was made
-      expect(spies.get('singleRecordQuery').callCount).to.equal(0);
+      // Verify no BotDefinition query was made (only determineOrg's Organization query may exist)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const botCalls = spies
+        .get('singleRecordQuery')
+        .args.filter((args: string[]) => args[0].includes('BotDefinition'));
+      expect(botCalls).to.have.lengthOf(0);
 
       const expectedPath = `AgentAuthoring/agentAuthoringBuilder.app#/project?projectName=${bundleName}`;
       expect(response.url).to.equal(getExpectedUrlWithPath(expectedPath));
@@ -242,7 +259,11 @@ describe('org:open:agent', () => {
       testJsonStructure(response);
       expect(spies.get('requestGet').callCount).to.equal(1);
       expect(spies.get('open').callCount).to.equal(1);
-      expect(spies.get('singleRecordQuery').callCount).to.equal(0);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const botCalls2 = spies
+        .get('singleRecordQuery')
+        .args.filter((args: string[]) => args[0].includes('BotDefinition'));
+      expect(botCalls2).to.have.lengthOf(0);
     });
   });
 
@@ -364,10 +385,12 @@ describe('org:open:agent', () => {
       const nonExistentVersion = '999';
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const singleRecordQueryStub = spies.get('singleRecordQuery');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      singleRecordQueryStub.onFirstCall().resolves({ Id: mockBotId }); // BotDefinition succeeds
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      singleRecordQueryStub.onSecondCall().rejects(new Error('No records found')); // BotVersion fails
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      singleRecordQueryStub.callsFake((query: string) => {
+        if (query.includes('FROM BotVersion')) return Promise.reject(new Error('No records found'));
+        if (query.includes('FROM BotDefinition')) return Promise.resolve({ Id: mockBotId });
+        return Promise.resolve({});
+      });
 
       try {
         await OrgOpenAgent.run([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,10 +1315,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.23.1", "@salesforce/core@^8.29.0", "@salesforce/core@^8.29.1", "@salesforce/core@^8.5.1":
-  version "8.29.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.29.1.tgz#8f867af889a620ff4c456701851794a2de9956dd"
-  integrity sha512-Pdo9yjKU6Lgm3CJOVJPTM4PzUHhTVMX43K5XmClsBEt75fs8mHNFALniHZwnZbVf+TSMfGsUygYAyTX6ShnNQA==
+"@salesforce/core@^8.23.1", "@salesforce/core@^8.29.0", "@salesforce/core@^8.29.1", "@salesforce/core@^8.31.0", "@salesforce/core@^8.5.1":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.0.tgz#153beb193af8fce73d31cc39afee794c4c1ee1c0"
+  integrity sha512-TXQoR7Bs0Dk5AuNY8eaNRhMeLDLcpJ8su7LVxn7VVfnRxITrRh4gkSuOAXdBKAqx0WcjRONDs1twedaOE7Xu4Q==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.13"
     "@salesforce/kit" "^3.2.4"
@@ -1327,7 +1327,7 @@
     change-case "^4.1.2"
     fast-levenshtein "^3.0.0"
     faye "^1.4.1"
-    form-data "^4.0.4"
+    form-data "^4.0.5"
     js2xmlparser "^4.0.1"
     jsonwebtoken "9.0.3"
     jszip "3.10.1"
@@ -1336,7 +1336,7 @@
     pino-abstract-transport "^1.2.0"
     pino-pretty "^11.3.0"
     proper-lockfile "^4.1.2"
-    semver "^7.7.3"
+    semver "^7.8.0"
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
@@ -3929,7 +3929,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^4.0.4:
+form-data@^4.0.4, form-data@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -6916,7 +6916,7 @@ semver@^6.0.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.4, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.3, semver@^7.7.4, semver@^7.8.0:
+semver@^7.3.4, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.4, semver@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
   integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,14 +1673,7 @@
     "@smithy/types" "^4.14.2"
     tslib "^2.6.2"
 
-"@smithy/types@^4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.1.tgz#aba92b4cdb406f2a2b062e82f1e3728d809a7c23"
-  integrity sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==
-  dependencies:
-    tslib "^2.6.2"
-
-"@smithy/types@^4.14.2":
+"@smithy/types@^4.14.1", "@smithy/types@^4.14.2":
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.2.tgz#6034ff1e0e52bfb7d744ac371b651a8bf21f30f1"
   integrity sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==
@@ -3775,7 +3768,7 @@ fast-wrap-ansi@^0.2.0:
   dependencies:
     fast-string-width "^3.0.2"
 
-fast-xml-builder@^1.1.5, fast-xml-builder@^1.1.7:
+fast-xml-builder@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
   integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
@@ -3783,23 +3776,13 @@ fast-xml-builder@^1.1.5, fast-xml-builder@^1.1.7:
     path-expression-matcher "^1.5.0"
     xml-naming "^0.1.0"
 
-fast-xml-parser@5.7.3:
+fast-xml-parser@5.7.3, fast-xml-parser@^5.7.2:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz#309b04b08d835defc62ab657a0bb340c0e0fbe6a"
   integrity sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==
   dependencies:
     "@nodable/entities" "^2.1.0"
     fast-xml-builder "^1.1.7"
-    path-expression-matcher "^1.5.0"
-    strnum "^2.2.3"
-
-fast-xml-parser@^5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz#fecd0b054c6c132fc03dab994a413da781e0eb9f"
-  integrity sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==
-  dependencies:
-    "@nodable/entities" "^2.1.0"
-    fast-xml-builder "^1.1.5"
     path-expression-matcher "^1.5.0"
     strnum "^2.2.3"
 


### PR DESCRIPTION
## Summary

@W-22583951@

- Remove sinon stubs for the now-deleted private `AuthInfo.getNamespacePrefix` method in sandbox NUT tests
- `getNamespacePrefix` was removed in `@salesforce/core` 8.31.0, replaced by the standalone `determineOrg` function which gracefully handles errors via try/catch
- yarn.lock deduplication from dependency resolution

## Change type

Dependency + test only — no source code changes.

## Test plan

- [ ] CI NUT tests pass (`sandboxResume.nut.ts`, `sandboxRefresh.nut.ts`) against `@salesforce/core` 8.31.0