### PR TITLE
fix: bump open package to latest-W-24154138

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ EXAMPLES
     $ sf org auth show-access-token --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/auth/show-access-token.ts)_
+_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-access-token.ts)_
 
 ## `sf org auth show-sfdx-auth-url`
 
@@ -205,7 +205,7 @@ EXAMPLES
     $ sf org auth show-sfdx-auth-url --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/auth/show-sfdx-auth-url.ts)_
+_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-sfdx-auth-url.ts)_
 
 ## `sf org auth show-user-password`
 
@@ -252,7 +252,7 @@ EXAMPLES
     $ sf org auth show-user-password --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/auth/show-user-password.ts)_
+_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-user-password.ts)_
 
 ## `sf org create agent-user`
 
@@ -330,7 +330,7 @@ FLAG DESCRIPTIONS
     "agent.user.<GUID>@your-org-domain.com".
 ```
 
-_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/create/agent-user.ts)_
+_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/agent-user.ts)_
 
 ## `sf org create sandbox`
 
@@ -464,7 +464,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when cloning an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/create/sandbox.ts)_
+_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/sandbox.ts)_
 
 ## `sf org create scratch`
 
@@ -646,7 +646,7 @@ FLAG DESCRIPTIONS
     Omit this flag to have Salesforce generate a unique username for your org.
 ```
 
-_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/create/scratch.ts)_
+_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/scratch.ts)_
 
 ## `sf org delete sandbox`
 
@@ -692,7 +692,7 @@ EXAMPLES
     $ sf org delete sandbox --target-org my-sandbox --no-prompt
 ```
 
-_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/delete/sandbox.ts)_
+_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/delete/sandbox.ts)_
 
 ## `sf org delete scratch`
 
@@ -736,7 +736,7 @@ EXAMPLES
     $ sf org delete scratch --target-org my-scratch-org --no-prompt
 ```
 
-_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/delete/scratch.ts)_
+_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/delete/scratch.ts)_
 
 ## `sf org disable tracking`
 
@@ -775,7 +775,7 @@ EXAMPLES
     $ sf org disable tracking
 ```
 
-_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/disable/tracking.ts)_
+_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/disable/tracking.ts)_
 
 ## `sf org display`
 
@@ -820,7 +820,7 @@ EXAMPLES
     $ sf org display --target-org TestOrg1 --verbose
 ```
 
-_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/display.ts)_
+_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/display.ts)_
 
 ## `sf org enable tracking`
 
@@ -862,7 +862,7 @@ EXAMPLES
     $ sf org enable tracking
 ```
 
-_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/enable/tracking.ts)_
+_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/enable/tracking.ts)_
 
 ## `sf org list`
 
@@ -901,7 +901,7 @@ EXAMPLES
     $ sf org list --clean
 ```
 
-_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/list.ts)_
+_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list.ts)_
 
 ## `sf org list metadata`
 
@@ -968,7 +968,7 @@ FLAG DESCRIPTIONS
     Examples of metadata types that use folders are Dashboard, Document, EmailTemplate, and Report.
 ```
 
-_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/list/metadata.ts)_
+_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list/metadata.ts)_
 
 ## `sf org list metadata-types`
 
@@ -1023,7 +1023,7 @@ FLAG DESCRIPTIONS
     Override the api version used for api requests made by this command
 ```
 
-_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/list/metadata-types.ts)_
+_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list/metadata-types.ts)_
 
 ## `sf org open`
 
@@ -1099,7 +1099,7 @@ EXAMPLES
     $ sf org open --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml
 ```
 
-_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/open.ts)_
+_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open.ts)_
 
 ## `sf org open agent`
 
@@ -1163,7 +1163,7 @@ EXAMPLES
     $ sf org open agent --authoring-bundle Coral_Cloud_Agent --version 1
 ```
 
-_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/open/agent.ts)_
+_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open/agent.ts)_
 
 ## `sf org open authoring-bundle`
 
@@ -1209,7 +1209,7 @@ EXAMPLES
     $ sf org open authoring-bundle --target-org MyTestOrg1 --browser firefox
 ```
 
-_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/open/authoring-bundle.ts)_
+_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open/authoring-bundle.ts)_
 
 ## `sf org refresh sandbox`
 
@@ -1312,7 +1312,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when refreshing an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/refresh/sandbox.ts)_
+_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/refresh/sandbox.ts)_
 
 ## `sf org resume sandbox`
 
@@ -1375,7 +1375,7 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the sandbox creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/resume/sandbox.ts)_
+_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/resume/sandbox.ts)_
 
 ## `sf org resume scratch`
 
@@ -1428,6 +1428,6 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the scratch creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.13/src/commands/org/resume/scratch.ts)_
+_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/resume/scratch.ts)_
 
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ EXAMPLES
     $ sf org auth show-access-token --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-access-token.ts)_
+_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-access-token.ts)_
 
 ## `sf org auth show-sfdx-auth-url`
 
@@ -205,7 +205,7 @@ EXAMPLES
     $ sf org auth show-sfdx-auth-url --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-sfdx-auth-url.ts)_
+_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-sfdx-auth-url.ts)_
 
 ## `sf org auth show-user-password`
 
@@ -252,7 +252,7 @@ EXAMPLES
     $ sf org auth show-user-password --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/auth/show-user-password.ts)_
+_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-user-password.ts)_
 
 ## `sf org create agent-user`
 
@@ -330,7 +330,7 @@ FLAG DESCRIPTIONS
     "agent.user.<GUID>@your-org-domain.com".
 ```
 
-_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/agent-user.ts)_
+_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/agent-user.ts)_
 
 ## `sf org create sandbox`
 
@@ -464,7 +464,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when cloning an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/sandbox.ts)_
+_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/sandbox.ts)_
 
 ## `sf org create scratch`
 
@@ -646,7 +646,7 @@ FLAG DESCRIPTIONS
     Omit this flag to have Salesforce generate a unique username for your org.
 ```
 
-_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/create/scratch.ts)_
+_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/scratch.ts)_
 
 ## `sf org delete sandbox`
 
@@ -692,7 +692,7 @@ EXAMPLES
     $ sf org delete sandbox --target-org my-sandbox --no-prompt
 ```
 
-_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/delete/sandbox.ts)_
+_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/delete/sandbox.ts)_
 
 ## `sf org delete scratch`
 
@@ -736,7 +736,7 @@ EXAMPLES
     $ sf org delete scratch --target-org my-scratch-org --no-prompt
 ```
 
-_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/delete/scratch.ts)_
+_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/delete/scratch.ts)_
 
 ## `sf org disable tracking`
 
@@ -775,7 +775,7 @@ EXAMPLES
     $ sf org disable tracking
 ```
 
-_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/disable/tracking.ts)_
+_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/disable/tracking.ts)_
 
 ## `sf org display`
 
@@ -820,7 +820,7 @@ EXAMPLES
     $ sf org display --target-org TestOrg1 --verbose
 ```
 
-_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/display.ts)_
+_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/display.ts)_
 
 ## `sf org enable tracking`
 
@@ -862,7 +862,7 @@ EXAMPLES
     $ sf org enable tracking
 ```
 
-_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/enable/tracking.ts)_
+_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/enable/tracking.ts)_
 
 ## `sf org list`
 
@@ -901,7 +901,7 @@ EXAMPLES
     $ sf org list --clean
 ```
 
-_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list.ts)_
+_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list.ts)_
 
 ## `sf org list metadata`
 
@@ -968,7 +968,7 @@ FLAG DESCRIPTIONS
     Examples of metadata types that use folders are Dashboard, Document, EmailTemplate, and Report.
 ```
 
-_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list/metadata.ts)_
+_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list/metadata.ts)_
 
 ## `sf org list metadata-types`
 
@@ -1023,7 +1023,7 @@ FLAG DESCRIPTIONS
     Override the api version used for api requests made by this command
 ```
 
-_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/list/metadata-types.ts)_
+_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list/metadata-types.ts)_
 
 ## `sf org open`
 
@@ -1099,7 +1099,7 @@ EXAMPLES
     $ sf org open --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml
 ```
 
-_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open.ts)_
+_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open.ts)_
 
 ## `sf org open agent`
 
@@ -1163,7 +1163,7 @@ EXAMPLES
     $ sf org open agent --authoring-bundle Coral_Cloud_Agent --version 1
 ```
 
-_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open/agent.ts)_
+_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open/agent.ts)_
 
 ## `sf org open authoring-bundle`
 
@@ -1209,7 +1209,7 @@ EXAMPLES
     $ sf org open authoring-bundle --target-org MyTestOrg1 --browser firefox
 ```
 
-_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/open/authoring-bundle.ts)_
+_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open/authoring-bundle.ts)_
 
 ## `sf org refresh sandbox`
 
@@ -1312,7 +1312,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when refreshing an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/refresh/sandbox.ts)_
+_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/refresh/sandbox.ts)_
 
 ## `sf org resume sandbox`
 
@@ -1375,7 +1375,7 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the sandbox creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/resume/sandbox.ts)_
+_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/resume/sandbox.ts)_
 
 ## `sf org resume scratch`
 
@@ -1428,6 +1428,6 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the scratch creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.0/src/commands/org/resume/scratch.ts)_
+_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/resume/scratch.ts)_
 
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ EXAMPLES
     $ sf org auth show-access-token --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-access-token.ts)_
+_See code: [src/commands/org/auth/show-access-token.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/auth/show-access-token.ts)_
 
 ## `sf org auth show-sfdx-auth-url`
 
@@ -205,7 +205,7 @@ EXAMPLES
     $ sf org auth show-sfdx-auth-url --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-sfdx-auth-url.ts)_
+_See code: [src/commands/org/auth/show-sfdx-auth-url.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/auth/show-sfdx-auth-url.ts)_
 
 ## `sf org auth show-user-password`
 
@@ -252,7 +252,7 @@ EXAMPLES
     $ sf org auth show-user-password --target-org my-org --json
 ```
 
-_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/auth/show-user-password.ts)_
+_See code: [src/commands/org/auth/show-user-password.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/auth/show-user-password.ts)_
 
 ## `sf org create agent-user`
 
@@ -330,7 +330,7 @@ FLAG DESCRIPTIONS
     "agent.user.<GUID>@your-org-domain.com".
 ```
 
-_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/agent-user.ts)_
+_See code: [src/commands/org/create/agent-user.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/create/agent-user.ts)_
 
 ## `sf org create sandbox`
 
@@ -464,7 +464,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when cloning an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/sandbox.ts)_
+_See code: [src/commands/org/create/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/create/sandbox.ts)_
 
 ## `sf org create scratch`
 
@@ -646,7 +646,7 @@ FLAG DESCRIPTIONS
     Omit this flag to have Salesforce generate a unique username for your org.
 ```
 
-_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/create/scratch.ts)_
+_See code: [src/commands/org/create/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/create/scratch.ts)_
 
 ## `sf org delete sandbox`
 
@@ -692,7 +692,7 @@ EXAMPLES
     $ sf org delete sandbox --target-org my-sandbox --no-prompt
 ```
 
-_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/delete/sandbox.ts)_
+_See code: [src/commands/org/delete/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/delete/sandbox.ts)_
 
 ## `sf org delete scratch`
 
@@ -736,7 +736,7 @@ EXAMPLES
     $ sf org delete scratch --target-org my-scratch-org --no-prompt
 ```
 
-_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/delete/scratch.ts)_
+_See code: [src/commands/org/delete/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/delete/scratch.ts)_
 
 ## `sf org disable tracking`
 
@@ -775,7 +775,7 @@ EXAMPLES
     $ sf org disable tracking
 ```
 
-_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/disable/tracking.ts)_
+_See code: [src/commands/org/disable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/disable/tracking.ts)_
 
 ## `sf org display`
 
@@ -820,7 +820,7 @@ EXAMPLES
     $ sf org display --target-org TestOrg1 --verbose
 ```
 
-_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/display.ts)_
+_See code: [src/commands/org/display.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/display.ts)_
 
 ## `sf org enable tracking`
 
@@ -862,7 +862,7 @@ EXAMPLES
     $ sf org enable tracking
 ```
 
-_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/enable/tracking.ts)_
+_See code: [src/commands/org/enable/tracking.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/enable/tracking.ts)_
 
 ## `sf org list`
 
@@ -901,7 +901,7 @@ EXAMPLES
     $ sf org list --clean
 ```
 
-_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list.ts)_
+_See code: [src/commands/org/list.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/list.ts)_
 
 ## `sf org list metadata`
 
@@ -968,7 +968,7 @@ FLAG DESCRIPTIONS
     Examples of metadata types that use folders are Dashboard, Document, EmailTemplate, and Report.
 ```
 
-_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list/metadata.ts)_
+_See code: [src/commands/org/list/metadata.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/list/metadata.ts)_
 
 ## `sf org list metadata-types`
 
@@ -1023,7 +1023,7 @@ FLAG DESCRIPTIONS
     Override the api version used for api requests made by this command
 ```
 
-_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/list/metadata-types.ts)_
+_See code: [src/commands/org/list/metadata-types.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/list/metadata-types.ts)_
 
 ## `sf org open`
 
@@ -1099,7 +1099,7 @@ EXAMPLES
     $ sf org open --source-file force-app/main/default/bots/Coral_Cloud_Agent/Coral_Cloud_Agent.bot-meta.xml
 ```
 
-_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open.ts)_
+_See code: [src/commands/org/open.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/open.ts)_
 
 ## `sf org open agent`
 
@@ -1163,7 +1163,7 @@ EXAMPLES
     $ sf org open agent --authoring-bundle Coral_Cloud_Agent --version 1
 ```
 
-_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open/agent.ts)_
+_See code: [src/commands/org/open/agent.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/open/agent.ts)_
 
 ## `sf org open authoring-bundle`
 
@@ -1209,7 +1209,7 @@ EXAMPLES
     $ sf org open authoring-bundle --target-org MyTestOrg1 --browser firefox
 ```
 
-_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/open/authoring-bundle.ts)_
+_See code: [src/commands/org/open/authoring-bundle.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/open/authoring-bundle.ts)_
 
 ## `sf org refresh sandbox`
 
@@ -1312,7 +1312,7 @@ FLAG DESCRIPTIONS
     You can specify either --source-sandbox-name or --source-id when refreshing an existing sandbox, but not both.
 ```
 
-_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/refresh/sandbox.ts)_
+_See code: [src/commands/org/refresh/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/refresh/sandbox.ts)_
 
 ## `sf org resume sandbox`
 
@@ -1375,7 +1375,7 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the sandbox creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/resume/sandbox.ts)_
+_See code: [src/commands/org/resume/sandbox.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/resume/sandbox.ts)_
 
 ## `sf org resume scratch`
 
@@ -1428,6 +1428,6 @@ FLAG DESCRIPTIONS
     returns the job ID. To resume checking the scratch creation, rerun this command.
 ```
 
-_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.1/src/commands/org/resume/scratch.ts)_
+_See code: [src/commands/org/resume/scratch.ts](https://github.com/salesforcecli/plugin-org/blob/6.0.14-dev.2/src/commands/org/resume/scratch.ts)_
 
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-org",
   "description": "Commands to interact with Salesforce orgs",
-  "version": "6.0.14-dev.0",
+  "version": "6.0.14-dev.1",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "enableO11y": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-org",
   "description": "Commands to interact with Salesforce orgs",
-  "version": "6.0.13",
+  "version": "6.0.14-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "enableO11y": true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ansis": "^3.16.0",
     "change-case": "^5.4.4",
     "is-wsl": "^3.1.1",
-    "open": "^11.0.1",
+    "open": "^11.0.3",
     "terminal-link": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-org",
   "description": "Commands to interact with Salesforce orgs",
-  "version": "6.0.14-dev.1",
+  "version": "6.0.14-dev.2",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "enableO11y": true,

--- a/src/shared/orgOpenCommandBase.ts
+++ b/src/shared/orgOpenCommandBase.ts
@@ -88,10 +88,6 @@ export abstract class OrgOpenCommandBase<T> extends SfCommand<T> {
         openOptions = { newInstance: platform() === 'darwin', app: { name: apps.browserPrivate } };
       }
     }
-    // open@11 on Windows: wait=true keeps piped stdio so the CLI stays alive until the browser launches.
-    if (platform() === 'win32') {
-      openOptions = { ...openOptions, wait: true };
-    }
     const cp = await utils.openUrl(url, openOptions);
     cp.on('error', (err) => {
       throw SfError.wrap(err);

--- a/src/shared/orgOpenCommandBase.ts
+++ b/src/shared/orgOpenCommandBase.ts
@@ -90,8 +90,25 @@ export abstract class OrgOpenCommandBase<T> extends SfCommand<T> {
     }
 
     const cp = await utils.openUrl(url, openOptions);
-    cp.on('error', (err) => {
-      throw SfError.wrap(err);
+    // Wait for the browser-opener to exit before the CLI tears it down.
+    await new Promise<void>((resolve, reject) => {
+      cp.on('error', (err) => {
+        reject(SfError.wrap(err));
+      });
+
+      const handleExit = (code: number | null): void => {
+        if (code && code > 0) {
+          reject(new SfError(`Failed to open browser (exit code ${code})`));
+        } else {
+          resolve();
+        }
+      };
+
+      if (cp.exitCode !== null) {
+        handleExit(cp.exitCode);
+      } else {
+        cp.on('exit', handleExit);
+      }
     });
 
     return output;

--- a/src/shared/orgOpenCommandBase.ts
+++ b/src/shared/orgOpenCommandBase.ts
@@ -88,27 +88,13 @@ export abstract class OrgOpenCommandBase<T> extends SfCommand<T> {
         openOptions = { newInstance: platform() === 'darwin', app: { name: apps.browserPrivate } };
       }
     }
-
+    // open@11 on Windows: wait=true keeps piped stdio so the CLI stays alive until the browser launches.
+    if (platform() === 'win32') {
+      openOptions = { ...openOptions, wait: true };
+    }
     const cp = await utils.openUrl(url, openOptions);
-    // Wait for the browser-opener to exit before the CLI tears it down.
-    await new Promise<void>((resolve, reject) => {
-      cp.on('error', (err) => {
-        reject(SfError.wrap(err));
-      });
-
-      const handleExit = (code: number | null): void => {
-        if (code && code > 0) {
-          reject(new SfError(`Failed to open browser (exit code ${code})`));
-        } else {
-          resolve();
-        }
-      };
-
-      if (cp.exitCode !== null) {
-        handleExit(cp.exitCode);
-      } else {
-        cp.on('exit', handleExit);
-      }
+    cp.on('error', (err) => {
+      throw SfError.wrap(err);
     });
 
     return output;

--- a/test/unit/org/open.test.ts
+++ b/test/unit/org/open.test.ts
@@ -56,7 +56,10 @@ describe('org:open', () => {
     stubUx($$.SANDBOX);
     stubSpinner($$.SANDBOX);
     await $$.stubAuths(testOrg);
-    spies.set('open', stubMethod($$.SANDBOX, utils, 'openUrl').resolves(new EventEmitter()));
+    spies.set(
+      'open',
+      stubMethod($$.SANDBOX, utils, 'openUrl').resolves(Object.assign(new EventEmitter(), { exitCode: 0 }))
+    );
     spies.set(
       'requestGet',
       stubMethod($$.SANDBOX, Connection.prototype, 'requestGet').callsFake((url: string) => {

--- a/test/unit/org/open.test.ts
+++ b/test/unit/org/open.test.ts
@@ -317,7 +317,7 @@ describe('org:open', () => {
 
       expect(spies.get('resolver').callCount).to.equal(1);
       expect(spies.get('open').callCount).to.equal(1);
-      expect(spies.get('open').args[0][1]).to.deep.equal(process.platform === 'win32' ? { wait: true } : {});
+      expect(spies.get('open').args[0][1]).to.deep.equal({});
     });
 
     it('calls open with a browser argument', async () => {

--- a/test/unit/org/open.test.ts
+++ b/test/unit/org/open.test.ts
@@ -317,7 +317,7 @@ describe('org:open', () => {
 
       expect(spies.get('resolver').callCount).to.equal(1);
       expect(spies.get('open').callCount).to.equal(1);
-      expect(spies.get('open').args[0][1]).to.deep.equal({});
+      expect(spies.get('open').args[0][1]).to.deep.equal(process.platform === 'win32' ? { wait: true } : {});
     });
 
     it('calls open with a browser argument', async () => {

--- a/test/unit/org/open/agent.test.ts
+++ b/test/unit/org/open/agent.test.ts
@@ -51,7 +51,10 @@ describe('org:open:agent', () => {
     stubUx($$.SANDBOX);
     stubSpinner($$.SANDBOX);
     await $$.stubAuths(testOrg);
-    spies.set('open', stubMethod($$.SANDBOX, utils, 'openUrl').resolves(new EventEmitter()));
+    spies.set(
+      'open',
+      stubMethod($$.SANDBOX, utils, 'openUrl').resolves(Object.assign(new EventEmitter(), { exitCode: 0 }))
+    );
     spies.set(
       'requestGet',
       stubMethod($$.SANDBOX, Connection.prototype, 'requestGet').callsFake((url: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,7 +2884,7 @@ default-browser-id@^5.0.0:
   resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.1.tgz#f7a7ccb8f5104bf8e0f71ba3b1ccfa5eafdb21e8"
   integrity sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==
 
-default-browser@^5.4.0:
+default-browser@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.5.1.tgz#1790affc52680fbb11e17cab2752d69aa2a37d2c"
   integrity sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==
@@ -5383,16 +5383,16 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/open/-/open-11.0.1.tgz#aabc32fa311acc8c0d7855938eb94583249c31bd"
-  integrity sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==
+open@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/open/-/open-11.0.3.tgz#ce13044e930beab892d30b485429a79225889641"
+  integrity sha512-b3souUgU0VaAvMmzA4+9cRgrOgMdE0vc9H9VhQ0FYnjjcyZ8R/f9DiwMU9V8rl+vjf05On9UJhbgb06fsTs87Q==
   dependencies:
-    default-browser "^5.4.0"
+    default-browser "^5.5.1"
     define-lazy-prop "^3.0.0"
     is-in-ssh "^1.0.0"
     is-inside-container "^1.0.0"
-    powershell-utils "^0.2.0"
+    powershell-utils "^0.2.1"
     wsl-utils "^1.0.0"
 
 optionator@^0.9.3:
@@ -5739,10 +5739,10 @@ powershell-utils@^0.1.0:
   resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.1.0.tgz#5a42c9a824fb4f2f251ccb41aaae73314f5d6ac2"
   integrity sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==
 
-powershell-utils@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.2.0.tgz#bb075dcadc1564f3bd80fddda4f0a481ccbdcf36"
-  integrity sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==
+powershell-utils@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.2.1.tgz#0853016f5b3c12d52b9571c8fe8059677d9ddbe2"
+  integrity sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### What does this PR do?
### Summary

  - Fixes race condition where sf org open exits before the browser-opener child process finishes launching the browser, causing intermittent
    failures — particularly on Windows and in VS Code's integrated terminal
  - Awaits the child process exit instead of fire-and-forget, with a guard for the case where the process has already exited before the handler is
    registered

### Test plan

  - [ ] sf org open opens browser reliably on Windows (standalone terminal and VS Code integrated terminal)
  - [ ] sf org open continues to work on macOS and Linux with no added delay
  - [ ] sf org open --url-only is unaffected (skips browser launch)
  - [ ] sf org open --browser firefox works
  - [ ] sf org open --private works
  - [x] Unit tests pass
### What issues does this PR fix or reference?
@W-24154138@
cli related issue: https://github.com/forcedotcom/cli/issues/3646